### PR TITLE
Mirror upstream elastic/elasticsearch#134329 for AI review

### DIFF
--- a/pr-134329.patch
+++ b/pr-134329.patch
@@ -1,0 +1,62 @@
+diff --git a/server/src/main/java/org/elasticsearch/TransportVersion.java b/server/src/main/java/org/elasticsearch/TransportVersion.java
+index cff3c22aa9e9eaaaf59edc859c3afb1d1fb1a295..f130f7d62e29b21f083ad3f40aedfbf5867741ef 100644
+--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
++++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
+@@ -117,7 +117,10 @@ public record TransportVersion(String name, int id, TransportVersion nextPatchVe
+         Integer upperBound
+     ) {
+         try {
+-            String line = bufferedReader.readLine();
++            String line;
++            do {
++                line = bufferedReader.readLine();
++            } while (line.replaceAll("\\s+", "").startsWith("#"));
+             String[] parts = line.replaceAll("\\s+", "").split(",");
+             String check;
+             while ((check = bufferedReader.readLine()) != null) {
+diff --git a/server/src/test/java/org/elasticsearch/TransportVersionTests.java b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+index 761ae19dbad7df7df8d65202b288cb12241425d0..e51ca0c553fb647d3c8055abb558641e7830e708 100644
+--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
++++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+@@ -354,4 +354,41 @@ public class TransportVersionTests extends ESTestCase {
+         assertThat(new TransportVersion(null, 100001000, null).supports(test4), is(true));
+         assertThat(new TransportVersion(null, 100001001, null).supports(test4), is(true));
+     }
++
++    public void testComment() {
++        byte[] data1 = ("#comment" + System.lineSeparator() + "1000000").getBytes(StandardCharsets.UTF_8);
++        TransportVersion test1 = TransportVersion.fromBufferedReader(
++            "<test>",
++            "testSupports3",
++            false,
++            true,
++            new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data1), StandardCharsets.UTF_8)),
++            5000000
++        );
++        assertThat(new TransportVersion(null, 1000000, null).supports(test1), is(true));
++
++        byte[] data2 = (" # comment" + System.lineSeparator() + "1000000").getBytes(StandardCharsets.UTF_8);
++        TransportVersion test2 = TransportVersion.fromBufferedReader(
++            "<test>",
++            "testSupports3",
++            false,
++            true,
++            new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data2), StandardCharsets.UTF_8)),
++            5000000
++        );
++        assertThat(new TransportVersion(null, 1000000, null).supports(test2), is(true));
++
++        byte[] data3 = ("#comment" + System.lineSeparator() + "# comment3" + System.lineSeparator() + "1000000").getBytes(
++            StandardCharsets.UTF_8
++        );
++        TransportVersion test3 = TransportVersion.fromBufferedReader(
++            "<test>",
++            "testSupports3",
++            false,
++            true,
++            new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data3), StandardCharsets.UTF_8)),
++            5000000
++        );
++        assertThat(new TransportVersion(null, 1000000, null).supports(test3), is(true));
++    }
+ }

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -117,7 +117,10 @@ public record TransportVersion(String name, int id, TransportVersion nextPatchVe
         Integer upperBound
     ) {
         try {
-            String line = bufferedReader.readLine();
+            String line;
+            do {
+                line = bufferedReader.readLine();
+            } while (line.replaceAll("\\s+", "").startsWith("#"));
             String[] parts = line.replaceAll("\\s+", "").split(",");
             String check;
             while ((check = bufferedReader.readLine()) != null) {

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -354,4 +354,41 @@ public class TransportVersionTests extends ESTestCase {
         assertThat(new TransportVersion(null, 100001000, null).supports(test4), is(true));
         assertThat(new TransportVersion(null, 100001001, null).supports(test4), is(true));
     }
+
+    public void testComment() {
+        byte[] data1 = ("#comment" + System.lineSeparator() + "1000000").getBytes(StandardCharsets.UTF_8);
+        TransportVersion test1 = TransportVersion.fromBufferedReader(
+            "<test>",
+            "testSupports3",
+            false,
+            true,
+            new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data1), StandardCharsets.UTF_8)),
+            5000000
+        );
+        assertThat(new TransportVersion(null, 1000000, null).supports(test1), is(true));
+
+        byte[] data2 = (" # comment" + System.lineSeparator() + "1000000").getBytes(StandardCharsets.UTF_8);
+        TransportVersion test2 = TransportVersion.fromBufferedReader(
+            "<test>",
+            "testSupports3",
+            false,
+            true,
+            new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data2), StandardCharsets.UTF_8)),
+            5000000
+        );
+        assertThat(new TransportVersion(null, 1000000, null).supports(test2), is(true));
+
+        byte[] data3 = ("#comment" + System.lineSeparator() + "# comment3" + System.lineSeparator() + "1000000").getBytes(
+            StandardCharsets.UTF_8
+        );
+        TransportVersion test3 = TransportVersion.fromBufferedReader(
+            "<test>",
+            "testSupports3",
+            false,
+            true,
+            new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data3), StandardCharsets.UTF_8)),
+            5000000
+        );
+        assertThat(new TransportVersion(null, 1000000, null).supports(test3), is(true));
+    }
 }


### PR DESCRIPTION
### **User description**
Patch from BASE=cf671ff721da8a26d4d3e30346b6bb639968f268 to HEAD=8021513035fb4cd706874e9b3301dc43fdef0845 on main. If partial, see *.rej in the tree.


___

### **PR Type**
Enhancement


___

### **Description**
- Add comment support to TransportVersion file parsing

- Skip lines starting with '#' in version files

- Add comprehensive tests for comment handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Version File"] -- "contains comments" --> B["fromBufferedReader()"]
  B -- "skip # lines" --> C["Parse Version"]
  C --> D["TransportVersion"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TransportVersion.java</strong><dd><code>Add comment line skipping logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/main/java/org/elasticsearch/TransportVersion.java

<ul><li>Modified <code>fromBufferedReader()</code> to skip comment lines<br> <li> Added do-while loop to ignore lines starting with '#'<br> <li> Enhanced file parsing robustness</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/12/files#diff-3e9f8961608cb91f073796642945c094c750f59b1f57b0ea7b710a33024ad78c">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TransportVersionTests.java</strong><dd><code>Add comment parsing test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/test/java/org/elasticsearch/TransportVersionTests.java

<ul><li>Added <code>testComment()</code> method with comprehensive test cases<br> <li> Tests single comment, spaced comment, and multiple comments<br> <li> Validates version parsing works correctly with comments</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/12/files#diff-f92d12ddc9833ee160c53dfc6693451345c9d0c1c4343cb57682601a39f24cec">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-134329.patch</strong><dd><code>Patch file for upstream changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr-134329.patch

<ul><li>Contains the complete patch diff for the changes<br> <li> Shows modifications to both source and test files</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/12/files#diff-288af2b47aee4978977012c5c01ef76f50f509b8e5f9755731f0ade062f48043">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

