### PR TITLE
Mirror upstream elastic/elasticsearch#133945 for AI review (snapshot of HEAD tree)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
@@ -90,7 +90,8 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
         int numCentroids,
         IndexInput centroids,
         float[] target,
-        IndexInput postingListSlice
+        IndexInput postingListSlice,
+        float visitRatio
     ) throws IOException;
 
     private static IndexInput openDataInput(
@@ -252,7 +253,8 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
             entry.numCentroids,
             entry.centroidSlice(ivfCentroids),
             target,
-            postListSlice
+            postListSlice,
+            visitRatio
         );
         PostingVisitor scorer = getPostingVisitor(fieldInfo, postListSlice, target, acceptDocs);
         long expectedDocs = 0;


### PR DESCRIPTION
### **User description**
Single commit with tree=0e24fc739f9daa5b003d20fb0fffaf197449db67^{tree}, parent=3c264cff967750ff7cb581defa42b0d69bb31fc6. Exact snapshot of upstream PR head. No conflict resolution attempted.


___

### **PR Type**
Enhancement


___

### **Description**
- Replace hardcoded centroid sampling percentage with dynamic visit ratio parameter

- Add centroid oversampling calculation for parent cluster configurations

- Improve IVF vector search flexibility through configurable sampling rates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded CENTROID_SAMPLING_PERCENTAGE"] --> B["Dynamic visitRatio parameter"]
  B --> C["Centroid oversampling calculation"]
  C --> D["Flexible buffer sizing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DefaultIVFVectorsReader.java</strong><dd><code>Replace hardcoded sampling with dynamic visit ratio</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsReader.java

<ul><li>Remove hardcoded <code>CENTROID_SAMPLING_PERCENTAGE</code> constant (0.2)<br> <li> Add <code>visitRatio</code> parameter to <code>getCentroidIterator</code> method<br> <li> Implement centroid oversampling calculation for parent clusters<br> <li> Update buffer size calculation to use dynamic ratio instead of fixed <br>percentage</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/22/files#diff-c46bfc4168cee08db3a75f1f849d4b802d6a35e438a93aa84fa05b8c22c9eee7">+10/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IVFVectorsReader.java</strong><dd><code>Add visitRatio parameter to abstract method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java

<ul><li>Add <code>visitRatio</code> parameter to abstract <code>getCentroidIterator</code> method <br>signature<br> <li> Pass <code>visitRatio</code> parameter through to concrete implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/22/files#diff-d1acaa2276724c84b4a867e3227114ba4928290e6d7d314ef199c94bb304d094">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

