### PR TITLE
Mirror upstream elastic/elasticsearch#133811 for AI review (snapshot of HEAD tree)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -24,6 +24,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.configuration.BuildFeatures;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.ProviderFactory;
@@ -55,6 +56,9 @@ public abstract class ElasticsearchTestBasePlugin implements Plugin<Project> {
 
     @Inject
     protected abstract ProviderFactory getProviderFactory();
+
+    @Inject
+    protected abstract BuildFeatures getBuildFeatures();
 
     @Override
     public void apply(Project project) {
@@ -164,9 +168,11 @@ public abstract class ElasticsearchTestBasePlugin implements Plugin<Project> {
             );
             test.systemProperties(sysprops);
 
-            // ignore changing test seed when build is passed -Dignore.tests.seed for cacheability experimentation
-            if (System.getProperty("ignore.tests.seed") != null) {
-                nonInputProperties.systemProperty("tests.seed", buildParams.get().getTestSeed());
+            // ignore changing test seed when build is passed -Dignore.tests.seed for cacheability
+            // also ignore when configuration cache is on since the test seed as task input would break
+            // configuration cache reuse.
+            if (System.getProperty("ignore.tests.seed") != null || getBuildFeatures().getConfigurationCache().getActive().get()) {
+                nonInputProperties.systemProperty("tests.seed", buildParams.get().getTestSeedProvider());
             } else {
                 test.systemProperty("tests.seed", buildParams.get().getTestSeed());
             }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParameterExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParameterExtension.java
@@ -56,6 +56,8 @@ public interface BuildParameterExtension {
 
     String getTestSeed();
 
+    Provider<String> getTestSeedProvider();
+
     Boolean getCi();
 
     Integer getDefaultParallel();
@@ -66,7 +68,7 @@ public interface BuildParameterExtension {
 
     Provider<BwcVersions> getBwcVersionsProvider();
 
-    Random getRandom();
+    Provider<Random> getRandom();
 
     Boolean getGraalVmRuntime();
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/DefaultBuildParameterExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/DefaultBuildParameterExtension.java
@@ -39,7 +39,7 @@ public abstract class DefaultBuildParameterExtension implements BuildParameterEx
     private final Provider<String> gitRevision;
 
     private transient AtomicReference<ZonedDateTime> buildDate = new AtomicReference<>();
-    private final String testSeed;
+    private final Provider<String> testSeed;
     private final Boolean isCi;
     private final Integer defaultParallel;
     private final Boolean snapshotBuild;
@@ -58,7 +58,7 @@ public abstract class DefaultBuildParameterExtension implements BuildParameterEx
         JavaVersion gradleJavaVersion,
         Provider<String> gitRevision,
         Provider<String> gitOrigin,
-        String testSeed,
+        Provider<String> testSeed,
         boolean isCi,
         int defaultParallel,
         final boolean isSnapshotBuild,
@@ -181,6 +181,11 @@ public abstract class DefaultBuildParameterExtension implements BuildParameterEx
 
     @Override
     public String getTestSeed() {
+        return testSeed.get();
+    }
+
+    @Override
+    public Provider<String> getTestSeedProvider() {
         return testSeed;
     }
 
@@ -205,8 +210,8 @@ public abstract class DefaultBuildParameterExtension implements BuildParameterEx
     }
 
     @Override
-    public Random getRandom() {
-        return new Random(Long.parseUnsignedLong(testSeed.split(":")[0], 16));
+    public Provider<Random> getRandom() {
+        return getTestSeedProvider().map(seed -> new Random(Long.parseUnsignedLong(seed.split(":")[0], 16)));
     }
 
     @Override

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -29,6 +29,7 @@ import org.gradle.api.JavaVersion;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.configuration.BuildFeatures;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
@@ -60,7 +61,6 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -87,7 +87,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
     private final JavaInstallationRegistry javaInstallationRegistry;
     private final JvmMetadataDetector metadataDetector;
     private final ProviderFactory providers;
-    private final BranchesFileParser branchesFileParser;
+    private final BuildFeatures buildFeatures;
     private JavaToolchainService toolChainService;
     private Project project;
 
@@ -96,13 +96,14 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         ObjectFactory objectFactory,
         JavaInstallationRegistry javaInstallationRegistry,
         JvmMetadataDetector metadataDetector,
-        ProviderFactory providers
+        ProviderFactory providers,
+        BuildFeatures buildFeatures
     ) {
         this.objectFactory = objectFactory;
         this.javaInstallationRegistry = javaInstallationRegistry;
         this.metadataDetector = new ErrorTraceMetadataDetector(metadataDetector);
         this.providers = providers;
-        this.branchesFileParser = new BranchesFileParser(new ObjectMapper());
+        this.buildFeatures = buildFeatures;
     }
 
     @Override
@@ -113,6 +114,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         this.project = project;
         project.getPlugins().apply(JvmToolchainsPlugin.class);
         project.getPlugins().apply(JdkDownloadPlugin.class);
+        project.getPlugins().apply(VersionPropertiesPlugin.class);
         Provider<GitInfo> gitInfo = project.getPlugins().apply(GitInfoPlugin.class).getGitInfo();
 
         toolChainService = project.getExtensions().getByType(JavaToolchainService.class);
@@ -121,11 +123,9 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             throw new GradleException("Gradle " + minimumGradleVersion.getVersion() + "+ is required");
         }
 
-        project.getPlugins().apply(VersionPropertiesPlugin.class);
         Properties versionProperties = (Properties) project.getExtensions().getByName(VERSIONS_EXT);
         JavaVersion minimumCompilerVersion = JavaVersion.toVersion(versionProperties.get("minimumCompilerJava"));
         JavaVersion minimumRuntimeVersion = JavaVersion.toVersion(versionProperties.get("minimumRuntimeJava"));
-
         Version elasticsearchVersionProperty = Version.fromString(versionProperties.getProperty("elasticsearch"));
 
         RuntimeJava runtimeJavaHome = findRuntimeJavaHome();
@@ -233,6 +233,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             }
         }
 
+        var branchesFileParser = new BranchesFileParser(new ObjectMapper());
         return branchesFileParser.parse(branchesBytes);
     }
 
@@ -266,7 +267,11 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         if (javaToolchainHome != null) {
             LOGGER.quiet("  JAVA_TOOLCHAIN_HOME   : " + javaToolchainHome);
         }
-        LOGGER.quiet("  Random Testing Seed   : " + buildParams.getTestSeed());
+
+        if (buildFeatures.getConfigurationCache().getActive().get() == false) {
+            // if configuration cache is enabled, resolving the test seed early breaks configuration cache reuse
+            LOGGER.quiet("  Random Testing Seed   : " + buildParams.getTestSeed());
+        }
         LOGGER.quiet("  In FIPS 140 mode      : " + buildParams.getInFipsJvm());
         LOGGER.quiet("=======================================");
     }
@@ -321,16 +326,8 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         );
     }
 
-    private static String getTestSeed() {
-        String testSeedProperty = System.getProperty("tests.seed");
-        final String testSeed;
-        if (testSeedProperty == null) {
-            long seed = new Random(System.currentTimeMillis()).nextLong();
-            testSeed = Long.toUnsignedString(seed, 16).toUpperCase(Locale.ROOT);
-        } else {
-            testSeed = testSeedProperty;
-        }
-        return testSeed;
+    private Provider<String> getTestSeed() {
+        return project.getProviders().of(TestSeedValueSource.class, spec -> {});
     }
 
     private static void throwInvalidJavaHomeException(String description, File javaHome, int expectedVersion, int actualVersion) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/TestSeedValueSource.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/TestSeedValueSource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.info;
+
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+
+import java.util.Locale;
+import java.util.Random;
+
+public abstract class TestSeedValueSource implements ValueSource<String, ValueSourceParameters.None> {
+
+    @Override
+    public ValueSourceParameters.None getParameters() {
+        return null;
+    }
+
+    @Override
+    public String obtain() {
+        String testSeedProperty = System.getProperty("tests.seed");
+        final String testSeed;
+        if (testSeedProperty == null) {
+            long seed = new Random(System.currentTimeMillis()).nextLong();
+            testSeed = Long.toUnsignedString(seed, 16).toUpperCase(Locale.ROOT);
+        } else {
+            testSeed = testSeedProperty;
+        }
+        return testSeed;
+    }
+}

--- a/x-pack/plugin/security/qa/profile/build.gradle
+++ b/x-pack/plugin/security/qa/profile/build.gradle
@@ -12,9 +12,7 @@ dependencies {
   javaRestTestImplementation project(':x-pack:plugin:security')
 }
 
-boolean literalUsername = buildParams.random.nextBoolean()
-
 tasks.named("javaRestTest").configure {
   usesDefaultDistribution("to be triaged")
-  systemProperty 'test.literalUsername', literalUsername
+  systemProperty 'test.literalUsername', buildParams.random.map{r -> r.nextBoolean()}.get()
 }

--- a/x-pack/plugin/sql/qa/jdbc/security/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/security/build.gradle
@@ -1,8 +1,4 @@
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
-import org.elasticsearch.gradle.testclusters.TestClusterValueSource
-import org.elasticsearch.gradle.testclusters.TestClustersPlugin
-import org.elasticsearch.gradle.testclusters.TestClustersRegistry
-import org.elasticsearch.gradle.util.GradleUtils
 
 apply plugin: 'elasticsearch.internal-test-artifact'
 

--- a/x-pack/qa/multi-cluster-search-security/legacy-with-basic-license/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/legacy-with-basic-license/build.gradle
@@ -19,7 +19,7 @@ restResources {
 }
 
 // randomise between sniff and proxy modes
-boolean proxyMode = buildParams.random.nextBoolean()
+var proxyModeProvider = buildParams.random.map{r -> r.nextBoolean()}
 
 def fulfillingCluster = testClusters.register('fulfilling-cluster') {
   setting 'xpack.security.enabled', 'true'
@@ -57,7 +57,7 @@ def queryingCluster = testClusters.register('querying-cluster') {
   user username: "test_user", password: "x-pack-test-password"
   setting 'xpack.ml.enabled', 'false'
   setting 'cluster.remote.my_remote_cluster.skip_unavailable', 'false'
-  if (proxyMode) {
+  if (proxyModeProvider.get()) {
     setting 'cluster.remote.my_remote_cluster.mode', 'proxy'
     setting 'cluster.remote.my_remote_cluster.proxy_address', {
       "\"${fulfillingCluster.get().getAllTransportPortURI().get(0)}\""
@@ -79,7 +79,7 @@ tasks.register('querying-cluster', RestIntegTestTask) {
   useCluster fulfillingCluster
   useCluster queryingCluster
   systemProperty 'tests.rest.suite', 'querying_cluster'
-  if (proxyMode) {
+  if (proxyModeProvider.get()) {
     systemProperty 'tests.rest.blacklist', [
       'querying_cluster/10_basic/Add persistent remote cluster based on the preset cluster',
       'querying_cluster/20_info/Add persistent remote cluster based on the preset cluster and check remote info',

--- a/x-pack/qa/multi-cluster-search-security/legacy-with-full-license/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/legacy-with-full-license/build.gradle
@@ -19,7 +19,7 @@ restResources {
 }
 
 // randomise between sniff and proxy modes
-boolean proxyMode = buildParams.random.nextBoolean()
+var proxyModeProvider = buildParams.random.map{r -> r.nextBoolean()}
 
 def fulfillingCluster = testClusters.register('fulfilling-cluster') {
   setting 'xpack.security.enabled', 'true'
@@ -43,7 +43,7 @@ def queryingCluster = testClusters.register('querying-cluster') {
   setting 'cluster.remote.connections_per_cluster', "1"
   user username: "test_user", password: "x-pack-test-password"
 
-  if (proxyMode) {
+  if (proxyModeProvider.get()) {
     setting 'cluster.remote.my_remote_cluster.mode', 'proxy'
     setting 'cluster.remote.my_remote_cluster.proxy_address', {
       "\"${fulfillingCluster.get().getAllTransportPortURI().get(0)}\""

--- a/x-pack/qa/multi-cluster-search-security/legacy-with-restricted-trust/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/legacy-with-restricted-trust/build.gradle
@@ -29,7 +29,7 @@ tasks.register("copyCerts", Sync) {
 }
 
 // randomise between sniff and proxy modes
-boolean proxyMode = buildParams.random.nextBoolean()
+var proxyModeProvider = buildParams.random.map{r -> r.nextBoolean()}
 
 def fulfillingCluster = testClusters.register('fulfilling-cluster') {
   setting 'xpack.security.enabled', 'true'
@@ -66,7 +66,7 @@ def queryingCluster = testClusters.register('querying-cluster') {
   setting 'cluster.remote.connections_per_cluster', "1"
   user username: "test_user", password: "x-pack-test-password"
 
-  if (proxyMode) {
+  if (proxyModeProvider.get()) {
     setting 'cluster.remote.my_remote_cluster.mode', 'proxy'
     setting 'cluster.remote.my_remote_cluster.proxy_address', {
       "\"${fulfillingCluster.get().getAllTransportPortURI().get(0)}\""


### PR DESCRIPTION
### **User description**
Single commit with tree=a25ede51f680602cdeeae9b45d1540ca9fbcc04f^{tree}, parent=24bd70b9d1eb60747a7ba3b7c971e2096da843fd. Exact snapshot of upstream PR head. No conflict resolution attempted.


___

### **PR Type**
Enhancement


___

### **Description**
- Improve configuration cache compatibility for test seed handling

- Convert test seed from static string to Provider-based approach

- Add conditional logic to ignore test seed when configuration cache is active

- Create new TestSeedValueSource for dynamic test seed generation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Seed Generation"] --> B["TestSeedValueSource"]
  B --> C["Provider<String>"]
  C --> D["Configuration Cache Check"]
  D --> E["Conditional Test Seed Usage"]
  E --> F["Enhanced Cache Reuse"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ElasticsearchTestBasePlugin.java</strong><dd><code>Enhanced test plugin with configuration cache support</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java

<ul><li>Add BuildFeatures injection for configuration cache detection<br> <li> Update test seed handling to use Provider instead of direct value<br> <li> Add conditional logic to ignore test seed when configuration cache is <br>active</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/31/files#diff-4ecf4ccbea42ff20067feebe70f5e2fcf436496807489244023af5ee4fa7d5b8">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BuildParameterExtension.java</strong><dd><code>Add Provider-based methods for test seed and random</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParameterExtension.java

<ul><li>Add getTestSeedProvider() method returning Provider<String><br> <li> Convert getRandom() method to return Provider<Random></ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/31/files#diff-3b4eec931ef5d7a1083f6435c45ffdbd9f15081598c984551ad4708cb7ab0085">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DefaultBuildParameterExtension.java</strong><dd><code>Refactor test seed handling to use Provider pattern</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/DefaultBuildParameterExtension.java

<ul><li>Convert testSeed field from String to Provider<String><br> <li> Update constructor to accept Provider<String> for test seed<br> <li> Implement new getTestSeedProvider() method<br> <li> Convert getRandom() to return Provider<Random></ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/31/files#diff-8bcda7d7e7a33f6936ac090d6c6662176c967a83f6883d5d18b7e57a2d616eb2">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GlobalBuildInfoPlugin.java</strong><dd><code>Implement Provider-based test seed generation with cache awareness</code></dd></summary>
<hr>

build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java

<ul><li>Add BuildFeatures injection for configuration cache detection<br> <li> Replace static getTestSeed() with Provider-based approach<br> <li> Add conditional logging of test seed based on configuration cache <br>status<br> <li> Create TestSeedValueSource for dynamic seed generation</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/31/files#diff-89e7026e7756cb7ccc5900c886f533a2dc93fc736c8f8a0922e8113bbcd4f31e">+14/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TestSeedValueSource.java</strong><dd><code>New ValueSource for configuration cache compatible test seeds</code></dd></summary>
<hr>

build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/TestSeedValueSource.java

<ul><li>New ValueSource implementation for dynamic test seed generation<br> <li> Handle both system property and random generation cases<br> <li> Provide configuration cache compatible seed generation</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/31/files#diff-6d73fe8dff9fddebdd6a2a561660a775beb49b720cee91bda95f36f5ab066aaa">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ElasticsearchTestBasePluginFuncTest.groovy</strong><dd><code>Add integration tests for dynamic test seed behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchTestBasePluginFuncTest.groovy

<ul><li>Add integration test for dynamic test seed generation<br> <li> Verify different seeds are used across invocations<br> <li> Test configuration cache reuse functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/31/files#diff-78ad03bda37e0e30b5883153b2a81dcee2efd862201da7103a3137b3d9cebb20">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

