### PR TITLE
Mirror upstream elastic/elasticsearch#134452 for AI review (snapshot of HEAD tree)

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expression.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expression.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -101,7 +102,9 @@ public abstract class Expression extends Node<Expression> implements Resolvable 
 
     public abstract Nullability nullable();
 
-    // the references/inputs/leaves of the expression tree
+    /**
+     * {@link Set} of {@link Attribute}s referenced by this {@link Expression}.
+     */
     public AttributeSet references() {
         if (lazyReferences == null) {
             lazyReferences = Expressions.references(children());

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expressions.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expressions.java
@@ -101,6 +101,15 @@ public final class Expressions {
     }
 
     public static AttributeSet references(List<? extends Expression> exps) {
+        if (exps.size() == 1) {
+            /*
+             * If we're getting the references from a single expression it's safe
+             * to just use its references. This is quite common. We use a ton of
+             * Aliases, for example. And every unary function can share its references
+             * with its input.
+             */
+            return exps.getFirst().references();
+        }
         return AttributeSet.of(exps, Expression::references);
     }
 


### PR DESCRIPTION
### **User description**
Single commit with tree=764dc377eb3029ca687c3878a462b7dfc2fba110^{tree}, parent=1b86c12b5dee47a90caa9f736ad2fb87877f35b7. Exact snapshot of upstream PR head. No conflict resolution attempted.


___

### **PR Type**
Enhancement


___

### **Description**
- Optimize single expression reference handling

- Add documentation for references method

- Import Set class for type clarity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Expression.references()"] --> B["Check expression count"]
  B --> C["Single expression?"]
  C -->|Yes| D["Return first.references()"]
  C -->|No| E["Use AttributeSet.of()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Expression.java</strong><dd><code>Add documentation and import for references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expression.java

<ul><li>Add import for <code>Set</code> class<br> <li> Add JavaDoc documentation for <code>references()</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/60/files#diff-9a1785291a1c7d128294c6c501c0bd9bcb440eb156a378e5eb09d4df98ee494f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Expressions.java</strong><dd><code>Optimize single expression references handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expressions.java

<ul><li>Add optimization for single expression case in <code>references()</code> method<br> <li> Return first expression's references directly when list size is 1<br> <li> Include detailed comment explaining the optimization rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/60/files#diff-a486f89def6dc31568af46bda1d4d82559d8ff06507d634b2ef9c4b9b73fd238">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

