### PR TITLE
Mirror upstream elastic/elasticsearch#134403 for AI review (snapshot of HEAD tree)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-avg-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-avg-over-time.csv-spec
@@ -100,6 +100,22 @@ tx:double          | cluster:keyword | time_bucket:datetime
 493.5              | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+avg_over_time_with_inline_filtering
+required_capability: metrics_command
+TS k8s | STATS tx = sum(avg_over_time(network.bytes_in)) WHERE pod == "one"  BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
+
+tx:double          | cluster:keyword | time_bucket:datetime
+293.0              | prod            | 2024-05-10T00:00:00.000Z
+482.6666666666667  | qa              | 2024-05-10T00:00:00.000Z
+494.1666666666667  | staging         | 2024-05-10T00:00:00.000Z
+601.5454545454545  | prod            | 2024-05-10T00:10:00.000Z
+496.14285714285717 | qa              | 2024-05-10T00:10:00.000Z
+441.6              | staging         | 2024-05-10T00:10:00.000Z
+633.3333333333334  | prod            | 2024-05-10T00:20:00.000Z
+440.0              | qa              | 2024-05-10T00:20:00.000Z
+493.5              | staging         | 2024-05-10T00:20:00.000Z
+;
+
 avg_over_time_older_than_10d
 required_capability: metrics_command
 required_capability: avg_over_time

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-last-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-last-over-time.csv-spec
@@ -106,6 +106,24 @@ tx:long | cluster:keyword | time_bucket:datetime
 238     | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+implicit_last_over_time_with_inline_filtering
+required_capability: metrics_command
+required_capability: implicit_last_over_time
+TS k8s  | STATS tx = sum(network.bytes_in) WHERE pod == "one" BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
+
+tx:long | cluster:keyword | time_bucket:datetime
+3       | prod            | 2024-05-10T00:00:00.000Z
+830     | qa              | 2024-05-10T00:00:00.000Z
+753     | staging         | 2024-05-10T00:00:00.000Z
+542     | prod            | 2024-05-10T00:10:00.000Z
+187     | qa              | 2024-05-10T00:10:00.000Z
+4       | staging         | 2024-05-10T00:10:00.000Z
+931     | prod            | 2024-05-10T00:20:00.000Z
+206     | qa              | 2024-05-10T00:20:00.000Z
+238     | staging         | 2024-05-10T00:20:00.000Z
+;
+
+
 
 last_over_time_older_than_10d
 required_capability: metrics_command

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
@@ -73,7 +73,24 @@ rate_bytes_in:double | cluster:keyword | time_bucket:datetime
 2.210158359293873    | prod            | 2024-05-10T00:20:00.000Z
 0.8955555555555565   | qa              | 2024-05-10T00:20:00.000Z
 0.595                | staging         | 2024-05-10T00:20:00.000Z
+;
 
+rate_with_inline_filtering
+required_capability: metrics_command
+TS k8s 
+| STATS rate_bytes_in = sum(rate(network.total_bytes_in)) WHERE pod == "one" BY cluster, time_bucket = bucket(@timestamp, 10minute)
+| SORT time_bucket, cluster | LIMIT 10;
+
+rate_bytes_in:double | cluster:keyword | time_bucket:datetime
+4.0314581958195825   | prod            | 2024-05-10T00:00:00.000Z
+9.955833333333333    | qa              | 2024-05-10T00:00:00.000Z
+4.242445473251029    | staging         | 2024-05-10T00:00:00.000Z
+11.188380281690138   | prod            | 2024-05-10T00:10:00.000Z
+12.222592592592592   | qa              | 2024-05-10T00:10:00.000Z
+3.050371490280777    | staging         | 2024-05-10T00:10:00.000Z
+2.210158359293873    | prod            | 2024-05-10T00:20:00.000Z
+0.8955555555555565   | qa              | 2024-05-10T00:20:00.000Z
+0.595                | staging         | 2024-05-10T00:20:00.000Z
 ;
 
 eval_on_rate

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
@@ -201,6 +201,24 @@ max(rate(network.total_bytes_in)):double | time_bucket:datetime     | cluster:ke
 11.562737642585551                       | 2024-05-10T00:10:00.000Z | prod
 ;
 
+maxRateWithInlineFilter
+required_capability: metrics_command
+TS k8s | STATS max_rate = max(rate(network.total_bytes_in)) WHERE cluster=="prod" BY cluster | SORT cluster;
+
+max_rate:double         | cluster:keyword
+8.716707021791768       | prod
+null                    | qa
+null                    | staging
+;
+
+maxRateWithPreFilter
+required_capability: metrics_command
+TS k8s | WHERE cluster=="prod" | STATS max_rate = max(rate(network.total_bytes_in)) BY cluster | SORT cluster;
+
+max_rate:double         | cluster:keyword
+8.716707021791768       | prod
+;
+
 notEnoughSamples
 required_capability: metrics_command
 TS k8s | WHERE @timestamp <= "2024-05-10T00:06:14.000Z" | STATS max(rate(network.total_bytes_in)) BY pod, time_bucket = bucket(@timestamp,1minute) | SORT pod, time_bucket DESC | LIMIT 10;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunction.java
@@ -11,7 +11,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.capabilities.PostAnalysisPlanVerificationAware;
 import org.elasticsearch.xpack.esql.common.Failures;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
@@ -150,6 +152,17 @@ public abstract class AggregateFunction extends Function implements PostAnalysis
             return this;
         }
         return (AggregateFunction) replaceChildren(CollectionUtils.combine(asList(field, filter), parameters));
+    }
+
+    /**
+     * Returns the set of input attributes required by this aggregate function, excluding those referenced by the filter.
+     */
+    public AttributeSet aggregateInputReferences() {
+        if (hasFilter()) {
+            return Expressions.references(CollectionUtils.combine(List.of(field), parameters));
+        } else {
+            return references();
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -279,7 +279,7 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
                             }
                         } else {
                             // extra dependencies like TS ones (that require a timestamp)
-                            for (Expression input : aggregateFunction.references()) {
+                            for (Expression input : aggregateFunction.aggregateInputReferences()) {
                                 Attribute attr = Expressions.attribute(input);
                                 if (attr == null) {
                                     throw new EsqlIllegalArgumentException(


### PR DESCRIPTION
### **User description**
Single commit with tree=e0ea2b27d76abbbfcea041510f9d0104fabacbbb^{tree}, parent=3e8b3083600c067b496defb7fcd39e8ea6e7852c. Exact snapshot of upstream PR head. No conflict resolution attempted.


___

### **PR Type**
Enhancement


___

### **Description**
- Add inline filter support for time-series aggregations

- Introduce `aggregateInputReferences()` method for better dependency tracking

- Update physical planner to use new reference method

- Add comprehensive test coverage for inline filtering scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AggregateFunction"] --> B["aggregateInputReferences()"]
  C["TranslateTimeSeriesAggregate"] --> D["Inline Filter Processing"]
  D --> E["Filter Propagation"]
  B --> F["AbstractPhysicalOperationProviders"]
  G["Test Coverage"] --> H["Inline Filter Tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AggregateFunction.java</strong><dd><code>Add aggregate input reference tracking method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunction.java

<ul><li>Add <code>aggregateInputReferences()</code> method to return input attributes <br>excluding filter references<br> <li> Import <code>AttributeSet</code> and <code>Expressions</code> classes for reference handling</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/61/files#diff-62f7c5912cc57e2688e8dba748253fe05ed65fb9b7fc63678e3abc2be333524e">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TranslateTimeSeriesAggregate.java</strong><dd><code>Implement inline filter support for time-series aggregates</code></dd></summary>
<hr>

x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java

<ul><li>Add inline filter extraction and propagation logic<br> <li> Handle filter state validation for time-series aggregations<br> <li> Update aggregate transformation to preserve inline filters<br> <li> Import <code>Literal</code> class for filter handling</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/61/files#diff-f18f5aa3ad82a6ca96e95cd1ddceb25ee951f9b8c5499ac947c3ac7027e361f3">+32/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AbstractPhysicalOperationProviders.java</strong><dd><code>Update physical planner to use new reference method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java

<ul><li>Replace <code>references()</code> with <code>aggregateInputReferences()</code> for dependency <br>tracking</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/61/files#diff-6c4fc399f42c99b8b8f599b5f79323d8d5090fb74f798b140e6b24e9f7f9ca4a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LogicalPlanOptimizerTests.java</strong><dd><code>Add unit tests for inline filter translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java

<ul><li>Add <code>testTranslateWithInlineFilter()</code> test for explicit last_over_time <br>with filter<br> <li> Add <code>testTranslateWithInlineFilterWithImplicitLastOverTime()</code> test for <br>implicit aggregation with filter<br> <li> Verify filter propagation and aggregate structure</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/61/files#diff-427544eaca2f06adb1b5850278a22573fb696564260a34a8f5580ff66bbbd95a">+64/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>k8s-timeseries-avg-over-time.csv-spec</strong><dd><code>Add integration test for avg_over_time with inline filter</code></dd></summary>
<hr>

x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-avg-over-time.csv-spec

<ul><li>Add <code>avg_over_time_with_inline_filtering</code> test case with WHERE clause</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/61/files#diff-0cb8048ac11229566551f8a0e6fb0ed9e2c9a356e4444b5bc71d0444d230b26b">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>k8s-timeseries-last-over-time.csv-spec</strong><dd><code>Add integration test for implicit last_over_time with inline filter</code></dd></summary>
<hr>

x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-last-over-time.csv-spec

<ul><li>Add <code>implicit_last_over_time_with_inline_filtering</code> test case with WHERE <br>clause</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/61/files#diff-604b87845cdff3e7163df6aca430f9519492248a362c1db9f59d977a19195dda">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>k8s-timeseries-rate.csv-spec</strong><dd><code>Add integration test for rate with inline filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec

- Add `rate_with_inline_filtering` test case with WHERE clause


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/61/files#diff-48d7ba4805018f5aae13611e0304cd63383c0cd5f7396b1415e8cc80bd5728e8">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>k8s-timeseries.csv-spec</strong><dd><code>Add integration tests for max rate with different filter types</code></dd></summary>
<hr>

x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec

<ul><li>Add <code>maxRateWithInlineFilter</code> test case with WHERE clause<br> <li> Add <code>maxRateWithPreFilter</code> test case for comparison</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/61/files#diff-2df7443c355691ac71b74f4e28fcc7de5cdbe1ed5020f84f2d73998260d971f0">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

