### PR TITLE
Mirror upstream elastic/elasticsearch#134347 for AI review (snapshot of HEAD tree)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -516,9 +516,6 @@ tests:
 - class: org.elasticsearch.action.support.nodes.TransportNodesActionTests
   method: testConcurrentlyCompletionAndCancellation
   issue: https://github.com/elastic/elasticsearch/issues/134277
-- class: org.elasticsearch.xpack.core.datastreams.TimeSeriesFeatureSetUsageTests
-  method: testEqualsAndHashcode
-  issue: https://github.com/elastic/elasticsearch/issues/134332
 
 # Examples:
 #

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/TimeSeriesFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/TimeSeriesFeatureSetUsage.java
@@ -34,8 +34,8 @@ import java.util.Objects;
  *   "time_series": {
  *      "enabled": true,
  *      "available": true,
- *      "data_streams_count": 10,
- *      "indices_count": 100,
+ *      "data_stream_count": 10,
+ *      "index_count": 100,
  *      "downsampling": {
  *         "index_count_per_interval": {
  *           "5m": 5,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/TimeSeriesFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/TimeSeriesFeatureSetUsageTests.java
@@ -57,7 +57,7 @@ public class TimeSeriesFeatureSetUsageTests extends AbstractWireSerializingTestC
         var dataStreamCount = instance.getTimeSeriesDataStreamCount();
         if (dataStreamCount == 0) {
             return new TimeSeriesFeatureSetUsage(
-                randomIntBetween(0, 100),
+                randomIntBetween(1, 100),
                 randomIntBetween(100, 100000),
                 TimeSeriesFeatureSetUsage.DownsamplingFeatureStats.EMPTY,
                 Map.of()


### PR DESCRIPTION
### **User description**
Single commit with tree=5389c60ff3c46eccadbc3f6fe9a6abeaed9dbf84^{tree}, parent=88f6798f4d6c95733b6c5c173615314f88d16719. Exact snapshot of upstream PR head. No conflict resolution attempted.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix telemetry field names in TimeSeriesFeatureSetUsage documentation

- Update test to prevent zero data stream count edge case

- Remove muted test that was previously failing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Documentation Fix"] --> B["Field Name Correction"]
  C["Test Fix"] --> D["Edge Case Prevention"]
  E["Muted Test"] --> F["Test Unmuting"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TimeSeriesFeatureSetUsage.java</strong><dd><code>Fix telemetry field names in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/TimeSeriesFeatureSetUsage.java

<ul><li>Update documentation comments to use correct field names<br> <li> Change <code>data_streams_count</code> to <code>data_stream_count</code><br> <li> Change <code>indices_count</code> to <code>index_count</code></ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/62/files#diff-ba6f8137a0d70bb64152d41cb8f3fa5fd8a2b2cc9214bed10781482fb4ddaf71">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TimeSeriesFeatureSetUsageTests.java</strong><dd><code>Fix test edge case with zero count</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/TimeSeriesFeatureSetUsageTests.java

<ul><li>Change random data stream count from <code>randomIntBetween(0, 100)</code> to <br><code>randomIntBetween(1, 100)</code><br> <li> Prevents zero data stream count in test mutation</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/62/files#diff-7806e1edb07f75d2f32c46ed88743c0df40840d0b9935b753c47ba7d28857d66">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>muted-tests.yml</strong><dd><code>Unmute previously failing test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

muted-tests.yml

<ul><li>Remove muted test entry for <br><code>TimeSeriesFeatureSetUsageTests.testEqualsAndHashcode</code><br> <li> Test is no longer failing and can be re-enabled</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/62/files#diff-41386766c394f14f5f205f92bb26eb1420b80af0057c78b2842fcc7ddd3d67aa">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

