### PR TITLE
Mirror upstream elastic/elasticsearch#134325 for AI review (snapshot of HEAD tree)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceResponseHandler.java
@@ -32,7 +32,7 @@ public class ElasticInferenceServiceResponseHandler extends BaseResponseHandler 
         }
 
         int statusCode = result.response().getStatusLine().getStatusCode();
-        if (statusCode == 500) {
+        if (statusCode == 500 || statusCode == 503) {
             throw new RetryException(true, buildError(SERVER_ERROR, request, result));
         } else if (statusCode == 400) {
             throw new RetryException(false, buildError(BAD_REQUEST, request, result));


### PR DESCRIPTION
### **User description**
Single commit with tree=7615402e5fe66dc8bb577e01562a36b4c10f72d2^{tree}, parent=ad5ecc8c5dfd1b6423abe3a73cb26fdd81e22ae8. Exact snapshot of upstream PR head. No conflict resolution attempted.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add HTTP 503 status code to retryable server errors

- Refactor tests to use parameterized test cases

- Remove unused import for ContentTooLargeException


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP Status Check"] --> B["500 or 503 Status"]
  B --> C["Retry Exception"]
  D["Test Cases"] --> E["Parameterized Tests"]
  E --> F["Multiple Status Codes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ElasticInferenceServiceResponseHandler.java</strong><dd><code>Add HTTP 503 to retryable server errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceResponseHandler.java

<ul><li>Modified condition to include HTTP 503 status code alongside 500 for <br>retryable server errors</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/64/files#diff-a76acd7ae34cbea672e6a43c4ea526879d07538fa2aa6108e9ae9733e5a73b14">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ElasticInferenceServiceResponseHandlerTests.java</strong><dd><code>Refactor to parameterized test structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceResponseHandlerTests.java

<ul><li>Converted individual test methods to parameterized test using <br><code>FailureTestCase</code> record<br> <li> Added test case for HTTP 503 status code<br> <li> Removed unused <code>ContentTooLargeException</code> import<br> <li> Added <code>ParametersFactory</code> import for parameterized testing</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/64/files#diff-98e962f711944e4e85c78594a081ce1ce4b90d400c4de730132d6860a7933232">+63/-47</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

