### PR TITLE
Mirror upstream elastic/elasticsearch#134413 for AI review (snapshot of HEAD tree)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tsdb-mapping.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tsdb-mapping.json
@@ -10,6 +10,10 @@
     "name": {
       "type": "keyword"
     },
+    "host": {
+      "type": "keyword",
+      "time_series_dimension": true
+    },
     "network": {
       "properties": {
         "connections": {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
@@ -10,7 +10,6 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
 import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
 import org.elasticsearch.xpack.esql.common.Failures;
@@ -29,7 +28,6 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.FilteredExpression;
-import org.elasticsearch.xpack.esql.expression.function.aggregate.Rate;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.TimeSeriesAggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.fulltext.FullTextFunction;
 import org.elasticsearch.xpack.esql.expression.function.grouping.Categorize;
@@ -243,16 +241,16 @@ public class Aggregate extends UnaryPlan
             // traverse the tree to find invalid matches
             checkInvalidNamedExpressionUsage(exp, groupings, groupRefs, failures, 0);
         });
-        if (anyMatch(l -> l instanceof EsRelation relation && relation.indexMode() == IndexMode.TIME_SERIES)) {
-            aggregates.forEach(a -> checkRateAggregates(a, 0, failures));
-        } else {
-            forEachExpression(
-                TimeSeriesAggregateFunction.class,
-                r -> failures.add(fail(r, "time_series aggregate[{}] can only be used with the TS command", r.sourceText()))
-            );
-        }
+        checkTimeSeriesAggregates(failures);
         checkCategorizeGrouping(failures);
         checkMultipleScoreAggregations(failures);
+    }
+
+    protected void checkTimeSeriesAggregates(Failures failures) {
+        forEachExpression(
+            TimeSeriesAggregateFunction.class,
+            r -> failures.add(fail(r, "time_series aggregate[{}] can only be used with the TS command", r.sourceText()))
+        );
     }
 
     private void checkMultipleScoreAggregations(Failures failures) {
@@ -351,22 +349,6 @@ public class Aggregate extends UnaryPlan
                 );
             }
         })));
-    }
-
-    private static void checkRateAggregates(Expression expr, int nestedLevel, Failures failures) {
-        if (expr instanceof AggregateFunction) {
-            nestedLevel++;
-        }
-        if (expr instanceof Rate r) {
-            if (nestedLevel != 2) {
-                failures.add(
-                    fail(expr, "the rate aggregate [{}] can only be used with the TS command and inside another aggregate", r.sourceText())
-                );
-            }
-        }
-        for (Expression child : expr.children()) {
-            checkRateAggregates(child, nestedLevel, failures);
-        }
     }
 
     // traverse the expression and look either for an agg function or a grouping match


### PR DESCRIPTION
### **User description**
Single commit with tree=69b95e47c4d65a8c6903b6f532b08d03d5406360^{tree}, parent=3c3058e6f63c5ebdcc4513fc5dcc4ffb3ec8a752. Exact snapshot of upstream PR head. No conflict resolution attempted.


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor time-series aggregate validation logic

- Add comprehensive validation for TS command constraints

- Improve error messages for time-series aggregates

- Add test coverage for TS command restrictions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Aggregate.java"] --> B["Extract checkTimeSeriesAggregates()"]
  B --> C["TimeSeriesAggregate.java"]
  C --> D["Override validation logic"]
  D --> E["Add TS command constraints"]
  E --> F["Enhanced error messages"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Aggregate.java</strong><dd><code>Refactor time-series validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java

<ul><li>Remove unused imports (<code>IndexMode</code>, <code>Rate</code>)<br> <li> Extract <code>checkTimeSeriesAggregates()</code> method for override capability<br> <li> Remove <code>checkRateAggregates()</code> method and related logic<br> <li> Simplify time-series validation to delegate to subclasses</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/66/files#diff-2a94d49d82689988b88bbb762111b0a3b06ee3970e52f74291b34b47e94d5794">+8/-26</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TimeSeriesAggregate.java</strong><dd><code>Add comprehensive TS command validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TimeSeriesAggregate.java

<ul><li>Add comprehensive <code>postAnalysisVerification()</code> method<br> <li> Implement validation for forbidden operations before TS aggregation<br> <li> Override <code>checkTimeSeriesAggregates()</code> with specific TS rules<br> <li> Add detailed error messages for various constraint violations</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/66/files#diff-f1054d2fef561b22223d9ffde8788624594416dc77d8da9fa287900739cf55c5">+133/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VerifierTests.java</strong><dd><code>Expand time-series validation test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java

<ul><li>Update test method name from <code>testRateNotEnclosedInAggregate</code> to <br><code>testTimeseriesAggregate</code><br> <li> Add tests for various time-series aggregate constraints<br> <li> Add <code>testSortInTimeSeries()</code> method for TS command restrictions<br> <li> Update expected error messages to match new validation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/66/files#diff-dc1d93bbf243d01dd99cc2c0ada85bb3fdbe8e21b677f54e0ecbe5e02b324c1b">+60/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tsdb-mapping.json</strong><dd><code>Add host dimension to test mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql/qa/testFixtures/src/main/resources/tsdb-mapping.json

- Add `host` field as time-series dimension


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/66/files#diff-2350ade4a09a74a21501b6630452235c1e99ba202b480dd0beb9662118c4fa68">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

