### PR TITLE
Mirror upstream elastic/elasticsearch#134799 for AI review (snapshot of HEAD tree)

### DIFF
--- a/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/search/retriever/AbstractRetrieverBuilderTests.java
+++ b/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/search/retriever/AbstractRetrieverBuilderTests.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.search.retriever;
+
+import org.elasticsearch.action.MockResolvedIndices;
+import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.action.ResolvedIndices;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.InferenceFieldMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.MultiMatchQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryRewriteContext;
+import org.elasticsearch.index.query.TermsQueryBuilder;
+import org.elasticsearch.search.retriever.CompoundRetrieverBuilder.RetrieverSource;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.rank.linear.ScoreNormalizer;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public abstract class AbstractRetrieverBuilderTests<T extends CompoundRetrieverBuilder<T>> extends ESTestCase {
+
+    protected abstract float[] getWeights(T builder);
+
+    protected abstract ScoreNormalizer[] getScoreNormalizers(T builder);
+
+    protected abstract void assertCompoundRetriever(T originalRetriever, RetrieverBuilder rewrittenRetriever);
+
+    protected static ResolvedIndices createMockResolvedIndices(
+        Map<String, List<String>> localIndexInferenceFields,
+        Map<String, String> remoteIndexNames,
+        Map<String, String> commonInferenceIds
+    ) {
+        Map<Index, IndexMetadata> indexMetadata = new HashMap<>();
+
+        for (var indexEntry : localIndexInferenceFields.entrySet()) {
+            String indexName = indexEntry.getKey();
+            List<String> inferenceFields = indexEntry.getValue();
+
+            Index index = new Index(indexName, randomAlphaOfLength(10));
+
+            IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(index.getName())
+                .settings(
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+                        .put(IndexMetadata.SETTING_INDEX_UUID, index.getUUID())
+                )
+                .numberOfShards(1)
+                .numberOfReplicas(0);
+
+            for (String inferenceField : inferenceFields) {
+                String inferenceId = commonInferenceIds.containsKey(inferenceField)
+                    ? commonInferenceIds.get(inferenceField)
+                    : randomAlphaOfLengthBetween(3, 5);
+
+                indexMetadataBuilder.putInferenceField(
+                    new InferenceFieldMetadata(inferenceField, inferenceId, new String[] { inferenceField }, null)
+                );
+            }
+
+            indexMetadata.put(index, indexMetadataBuilder.build());
+        }
+
+        Map<String, OriginalIndices> remoteIndices = new HashMap<>();
+        if (remoteIndexNames != null) {
+            for (Map.Entry<String, String> entry : remoteIndexNames.entrySet()) {
+                remoteIndices.put(entry.getKey(), new OriginalIndices(new String[] { entry.getValue() }, IndicesOptions.DEFAULT));
+            }
+        }
+
+        return new MockResolvedIndices(
+            remoteIndices,
+            new OriginalIndices(localIndexInferenceFields.keySet().toArray(new String[0]), IndicesOptions.DEFAULT),
+            indexMetadata
+        );
+    }
+
+    protected void assertMultiFieldsParamsRewrite(
+        T retriever,
+        QueryRewriteContext ctx,
+        Map<String, Float> expectedNonInferenceFields,
+        Map<String, Float> expectedInferenceFields,
+        String expectedQuery,
+        ScoreNormalizer expectedNormalizer
+    ) {
+        Map<Tuple<String, List<String>>, Float> inferenceFields = new HashMap<>();
+        expectedInferenceFields.forEach((key, value) -> inferenceFields.put(new Tuple<>(key, List.of()), value));
+
+        assertMultiIndexMultiFieldsParamsRewrite(
+            retriever,
+            ctx,
+            Map.of(expectedNonInferenceFields, List.of()),
+            inferenceFields,
+            expectedQuery,
+            expectedNormalizer
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void assertMultiIndexMultiFieldsParamsRewrite(
+        T retriever,
+        QueryRewriteContext ctx,
+        Map<Map<String, Float>, List<String>> expectedNonInferenceFields,
+        Map<Tuple<String, List<String>>, Float> expectedInferenceFields,
+        String expectedQuery,
+        ScoreNormalizer expectedNormalizer
+    ) {
+        Set<QueryBuilder> expectedLexicalQueryBuilders = expectedNonInferenceFields.entrySet().stream().map(entry -> {
+            Map<String, Float> fields = entry.getKey();
+            List<String> indices = entry.getValue();
+
+            QueryBuilder queryBuilder = new MultiMatchQueryBuilder(expectedQuery).type(MultiMatchQueryBuilder.Type.MOST_FIELDS)
+                .fields(fields);
+
+            if (indices.isEmpty() == false) {
+                queryBuilder = new BoolQueryBuilder().must(queryBuilder).filter(new TermsQueryBuilder("_index", indices));
+            }
+            return queryBuilder;
+        }).collect(Collectors.toSet());
+
+        Set<InnerRetriever> expectedInnerSemanticRetrievers = expectedInferenceFields.entrySet().stream().map(entry -> {
+            var groupedInferenceField = entry.getKey();
+            var fieldName = groupedInferenceField.v1();
+            var indices = groupedInferenceField.v2();
+            var weight = entry.getValue();
+            QueryBuilder queryBuilder = new MatchQueryBuilder(fieldName, expectedQuery);
+            if (indices.isEmpty() == false) {
+                queryBuilder = new BoolQueryBuilder().must(queryBuilder).filter(new TermsQueryBuilder("_index", indices));
+            }
+            return new InnerRetriever(new StandardRetrieverBuilder(queryBuilder), weight, expectedNormalizer);
+        }).collect(Collectors.toSet());
+
+        RetrieverBuilder rewritten = retriever.doRewrite(ctx);
+        assertNotSame(retriever, rewritten);
+        assertCompoundRetriever(retriever, rewritten);
+
+        boolean assertedLexical = false;
+        boolean assertedSemantic = false;
+
+        for (InnerRetriever topInnerRetriever : getInnerRetrieversAsSet(retriever, (T) rewritten)) {
+            assertEquals(expectedNormalizer, topInnerRetriever.normalizer);
+            assertEquals(1.0f, topInnerRetriever.weight, 0.0f);
+
+            if (topInnerRetriever.retriever instanceof StandardRetrieverBuilder standardRetrieverBuilder) {
+                assertFalse("the lexical retriever is only asserted once", assertedLexical);
+                assertFalse(expectedNonInferenceFields.isEmpty());
+
+                QueryBuilder topDocsQueryBuilder = standardRetrieverBuilder.topDocsQuery();
+                if (expectedLexicalQueryBuilders.size() == 1) {
+                    assertEquals(topDocsQueryBuilder, expectedLexicalQueryBuilders.iterator().next());
+                } else {
+                    assertTrue(topDocsQueryBuilder instanceof BoolQueryBuilder);
+                    BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) topDocsQueryBuilder;
+                    assertEquals(new HashSet<>(expectedLexicalQueryBuilders), new HashSet<>(boolQueryBuilder.should()));
+                }
+                assertedLexical = true;
+            } else {
+                assertFalse("the semantic retriever is only asserted once", assertedSemantic);
+                assertFalse(expectedInferenceFields.isEmpty());
+                assertEquals(expectedInnerSemanticRetrievers, topInnerRetriever.retriever);
+                assertedSemantic = true;
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<InnerRetriever> getInnerRetrieversAsSet(T originalRetriever, T rewrittenRetriever) {
+        float[] weights = getWeights(rewrittenRetriever);
+        ScoreNormalizer[] normalizers = getScoreNormalizers(rewrittenRetriever);
+
+        int i = 0;
+        Set<InnerRetriever> innerRetrieversSet = new HashSet<>();
+        for (RetrieverSource innerRetriever : rewrittenRetriever.innerRetrievers()) {
+            float weight = weights[i];
+            ScoreNormalizer normalizer = normalizers != null ? normalizers[i] : null;
+
+            if (innerRetriever.retriever() instanceof CompoundRetrieverBuilder<?> compoundRetriever) {
+                assertCompoundRetriever(originalRetriever, compoundRetriever);
+                innerRetrieversSet.add(
+                    new InnerRetriever(getInnerRetrieversAsSet(originalRetriever, (T) compoundRetriever), weight, normalizer)
+                );
+            } else {
+                innerRetrieversSet.add(new InnerRetriever(innerRetriever.retriever(), weight, normalizer));
+            }
+
+            i++;
+        }
+
+        return innerRetrieversSet;
+    }
+
+    private static class InnerRetriever {
+        private final Object retriever;
+        private final float weight;
+        private final ScoreNormalizer normalizer;
+
+        InnerRetriever(RetrieverBuilder retriever, float weight, ScoreNormalizer normalizer) {
+            this.retriever = retriever;
+            this.weight = weight;
+            this.normalizer = normalizer;
+        }
+
+        InnerRetriever(Set<InnerRetriever> innerRetrievers, float weight, ScoreNormalizer normalizer) {
+            this.retriever = innerRetrievers;
+            this.weight = weight;
+            this.normalizer = normalizer;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            InnerRetriever that = (InnerRetriever) o;
+            return Float.compare(weight, that.weight) == 0
+                && Objects.equals(retriever, that.retriever)
+                && Objects.equals(normalizer, that.normalizer);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(retriever, weight, normalizer);
+        }
+    }
+}

--- a/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/linear/LinearRetrieverBuilderTests.java
+++ b/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/linear/LinearRetrieverBuilderTests.java
@@ -8,43 +8,26 @@
 package org.elasticsearch.xpack.rank.linear;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.action.MockResolvedIndices;
-import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.ResolvedIndices;
-import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.InferenceFieldMetadata;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.index.Index;
-import org.elasticsearch.index.IndexVersion;
-import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
-import org.elasticsearch.index.query.MultiMatchQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.search.builder.PointInTimeBuilder;
+import org.elasticsearch.search.retriever.AbstractRetrieverBuilderTests;
 import org.elasticsearch.search.retriever.CompoundRetrieverBuilder;
 import org.elasticsearch.search.retriever.KnnRetrieverBuilder;
 import org.elasticsearch.search.retriever.RetrieverBuilder;
 import org.elasticsearch.search.retriever.StandardRetrieverBuilder;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.RemoteClusterAware;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.IVF_FORMAT;
 import static org.elasticsearch.search.rank.RankBuilder.DEFAULT_RANK_WINDOW_SIZE;
 
-public class LinearRetrieverBuilderTests extends ESTestCase {
+public class LinearRetrieverBuilderTests extends AbstractRetrieverBuilderTests<LinearRetrieverBuilder> {
     public void testMultiFieldsParamsRewrite() {
         final String indexName = "test-index";
         final List<String> testInferenceFields = List.of("semantic_field_1", "semantic_field_2");
@@ -573,200 +556,6 @@ public class LinearRetrieverBuilderTests extends ESTestCase {
         assertEquals("[linear] cannot specify [query] when querying remote indices", iae.getMessage());
     }
 
-    private static ResolvedIndices createMockResolvedIndices(
-        Map<String, List<String>> localIndexInferenceFields,
-        Map<String, String> remoteIndexNames,
-        Map<String, String> commonInferenceIds
-    ) {
-        Map<Index, IndexMetadata> indexMetadata = new HashMap<>();
-
-        for (var indexEntry : localIndexInferenceFields.entrySet()) {
-            String indexName = indexEntry.getKey();
-            List<String> inferenceFields = indexEntry.getValue();
-
-            Index index = new Index(indexName, randomAlphaOfLength(10));
-
-            IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(index.getName())
-                .settings(
-                    Settings.builder()
-                        .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
-                        .put(IndexMetadata.SETTING_INDEX_UUID, index.getUUID())
-                )
-                .numberOfShards(1)
-                .numberOfReplicas(0);
-
-            for (String inferenceField : inferenceFields) {
-                String inferenceId = commonInferenceIds.containsKey(inferenceField)
-                    ? commonInferenceIds.get(inferenceField)
-                    : randomAlphaOfLengthBetween(3, 5);
-
-                indexMetadataBuilder.putInferenceField(
-                    new InferenceFieldMetadata(inferenceField, inferenceId, new String[] { inferenceField }, null)
-                );
-            }
-
-            indexMetadata.put(index, indexMetadataBuilder.build());
-        }
-
-        Map<String, OriginalIndices> remoteIndices = new HashMap<>();
-        if (remoteIndexNames != null) {
-            for (Map.Entry<String, String> entry : remoteIndexNames.entrySet()) {
-                remoteIndices.put(entry.getKey(), new OriginalIndices(new String[] { entry.getValue() }, IndicesOptions.DEFAULT));
-            }
-        }
-
-        return new MockResolvedIndices(
-            remoteIndices,
-            new OriginalIndices(localIndexInferenceFields.keySet().toArray(new String[0]), IndicesOptions.DEFAULT),
-            indexMetadata
-        );
-    }
-
-    private static void assertMultiFieldsParamsRewrite(
-        LinearRetrieverBuilder retriever,
-        QueryRewriteContext ctx,
-        Map<String, Float> expectedNonInferenceFields,
-        Map<String, Float> expectedInferenceFields,
-        String expectedQuery,
-        ScoreNormalizer expectedNormalizer
-    ) {
-        Map<Tuple<String, List<String>>, Float> inferenceFields = new HashMap<>();
-        expectedInferenceFields.forEach((key, value) -> inferenceFields.put(new Tuple<>(key, List.of()), value));
-
-        assertMultiIndexMultiFieldsParamsRewrite(
-            retriever,
-            ctx,
-            Map.of(expectedNonInferenceFields, List.of()),
-            inferenceFields,
-            expectedQuery,
-            expectedNormalizer
-        );
-    }
-
-    private static void assertMultiIndexMultiFieldsParamsRewrite(
-        LinearRetrieverBuilder retriever,
-        QueryRewriteContext ctx,
-        Map<Map<String, Float>, List<String>> expectedNonInferenceFields,
-        Map<Tuple<String, List<String>>, Float> expectedInferenceFields,
-        String expectedQuery,
-        ScoreNormalizer expectedNormalizer
-    ) {
-        Set<QueryBuilder> expectedLexicalQueryBuilders = expectedNonInferenceFields.entrySet().stream().map(entry -> {
-            Map<String, Float> fields = entry.getKey();
-            List<String> indices = entry.getValue();
-
-            QueryBuilder queryBuilder = new MultiMatchQueryBuilder(expectedQuery).type(MultiMatchQueryBuilder.Type.MOST_FIELDS)
-                .fields(fields);
-
-            if (indices.isEmpty() == false) {
-                queryBuilder = new BoolQueryBuilder().must(queryBuilder).filter(new TermsQueryBuilder("_index", indices));
-            }
-            return queryBuilder;
-        }).collect(Collectors.toSet());
-
-        Set<InnerRetriever> expectedInnerSemanticRetrievers = expectedInferenceFields.entrySet().stream().map(entry -> {
-            var groupedInferenceField = entry.getKey();
-            var fieldName = groupedInferenceField.v1();
-            var indices = groupedInferenceField.v2();
-            var weight = entry.getValue();
-            QueryBuilder queryBuilder = new MatchQueryBuilder(fieldName, expectedQuery);
-            if (indices.isEmpty() == false) {
-                queryBuilder = new BoolQueryBuilder().must(queryBuilder).filter(new TermsQueryBuilder("_index", indices));
-            }
-            return new InnerRetriever(new StandardRetrieverBuilder(queryBuilder), weight, expectedNormalizer);
-        }).collect(Collectors.toSet());
-
-        RetrieverBuilder rewritten = retriever.doRewrite(ctx);
-        assertNotSame(retriever, rewritten);
-        assertTrue(rewritten instanceof LinearRetrieverBuilder);
-        LinearRetrieverBuilder rewrittenLinear = (LinearRetrieverBuilder) rewritten;
-        assertEquals(retriever.rankWindowSize(), rewrittenLinear.rankWindowSize());
-
-        boolean assertedLexical = false;
-        boolean assertedSemantic = false;
-
-        for (InnerRetriever topInnerRetriever : getInnerRetrieversAsSet(rewrittenLinear)) {
-            assertEquals(expectedNormalizer, topInnerRetriever.normalizer);
-            assertEquals(1.0f, topInnerRetriever.weight, 0.0f);
-
-            if (topInnerRetriever.retriever instanceof StandardRetrieverBuilder standardRetrieverBuilder) {
-                assertFalse("the lexical retriever is only asserted once", assertedLexical);
-                assertFalse(expectedNonInferenceFields.isEmpty());
-
-                QueryBuilder topDocsQueryBuilder = standardRetrieverBuilder.topDocsQuery();
-                if (expectedLexicalQueryBuilders.size() == 1) {
-                    assertEquals(topDocsQueryBuilder, expectedLexicalQueryBuilders.iterator().next());
-                } else {
-                    assertTrue(topDocsQueryBuilder instanceof BoolQueryBuilder);
-                    BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) topDocsQueryBuilder;
-                    assertEquals(new HashSet<>(expectedLexicalQueryBuilders), new HashSet<>(boolQueryBuilder.should()));
-                }
-                assertedLexical = true;
-            } else {
-                assertFalse("the semantic retriever is only asserted once", assertedSemantic);
-                assertFalse(expectedInferenceFields.isEmpty());
-                assertEquals(expectedInnerSemanticRetrievers, topInnerRetriever.retriever);
-                assertedSemantic = true;
-            }
-        }
-    }
-
-    private static Set<InnerRetriever> getInnerRetrieversAsSet(LinearRetrieverBuilder retriever) {
-        float[] weights = retriever.getWeights();
-        ScoreNormalizer[] normalizers = retriever.getNormalizers();
-
-        int i = 0;
-        Set<InnerRetriever> innerRetrieversSet = new HashSet<>();
-        for (CompoundRetrieverBuilder.RetrieverSource innerRetriever : retriever.innerRetrievers()) {
-            float weight = weights[i];
-            ScoreNormalizer normalizer = normalizers[i];
-
-            if (innerRetriever.retriever() instanceof LinearRetrieverBuilder innerLinearRetriever) {
-                assertEquals(retriever.rankWindowSize(), innerLinearRetriever.rankWindowSize());
-                innerRetrieversSet.add(new InnerRetriever(getInnerRetrieversAsSet(innerLinearRetriever), weight, normalizer));
-            } else {
-                innerRetrieversSet.add(new InnerRetriever(innerRetriever.retriever(), weight, normalizer));
-            }
-
-            i++;
-        }
-
-        return innerRetrieversSet;
-    }
-
-    private static class InnerRetriever {
-        private final Object retriever;
-        private final float weight;
-        private final ScoreNormalizer normalizer;
-
-        InnerRetriever(RetrieverBuilder retriever, float weight, ScoreNormalizer normalizer) {
-            this.retriever = retriever;
-            this.weight = weight;
-            this.normalizer = normalizer;
-        }
-
-        InnerRetriever(Set<InnerRetriever> innerRetrievers, float weight, ScoreNormalizer normalizer) {
-            this.retriever = innerRetrievers;
-            this.weight = weight;
-            this.normalizer = normalizer;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            InnerRetriever that = (InnerRetriever) o;
-            return Float.compare(weight, that.weight) == 0
-                && Objects.equals(retriever, that.retriever)
-                && Objects.equals(normalizer, that.normalizer);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(retriever, weight, normalizer);
-        }
-    }
-
     public void testTopLevelNormalizerWithRetrieversArray() {
         StandardRetrieverBuilder standardRetriever = new StandardRetrieverBuilder(new MatchQueryBuilder("title", "elasticsearch"));
         KnnRetrieverBuilder knnRetriever = new KnnRetrieverBuilder(
@@ -866,4 +655,20 @@ public class LinearRetrieverBuilderTests extends ESTestCase {
         assertEquals(IdentityScoreNormalizer.INSTANCE, retriever.getNormalizers()[2]);
     }
 
+    @Override
+    protected float[] getWeights(LinearRetrieverBuilder builder) {
+        return builder.getWeights();
+    }
+
+    @Override
+    protected ScoreNormalizer[] getScoreNormalizers(LinearRetrieverBuilder builder) {
+        return builder.getNormalizers();
+    }
+
+    @Override
+    protected void assertCompoundRetriever(LinearRetrieverBuilder originalRetriever, RetrieverBuilder rewrittenRetriever) {
+        assertTrue(rewrittenRetriever instanceof LinearRetrieverBuilder);
+        LinearRetrieverBuilder actualRetrieverBuilder = (LinearRetrieverBuilder) rewrittenRetriever;
+        assertEquals(originalRetriever.rankWindowSize(), actualRetrieverBuilder.rankWindowSize());
+    }
 }

--- a/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
+++ b/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
@@ -8,46 +8,33 @@
 package org.elasticsearch.xpack.rank.rrf;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.action.MockResolvedIndices;
-import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.ResolvedIndices;
-import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.InferenceFieldMetadata;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.Index;
-import org.elasticsearch.index.IndexVersion;
-import org.elasticsearch.index.query.MatchQueryBuilder;
-import org.elasticsearch.index.query.MultiMatchQueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.retriever.CompoundRetrieverBuilder;
+import org.elasticsearch.search.retriever.AbstractRetrieverBuilderTests;
 import org.elasticsearch.search.retriever.RetrieverBuilder;
 import org.elasticsearch.search.retriever.RetrieverParserContext;
-import org.elasticsearch.search.retriever.StandardRetrieverBuilder;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.rank.linear.ScoreNormalizer;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.BiConsumer;
 
 import static org.elasticsearch.search.rank.RankBuilder.DEFAULT_RANK_WINDOW_SIZE;
 import static org.hamcrest.Matchers.instanceOf;
 
 /** Tests for the rrf retriever. */
-public class RRFRetrieverBuilderTests extends ESTestCase {
+public class RRFRetrieverBuilderTests extends AbstractRetrieverBuilderTests<RRFRetrieverBuilder> {
 
     /** Tests extraction errors related to compound retrievers. These tests require a compound retriever which is why they are here. */
     public void testRetrieverExtractionErrors() throws IOException {
@@ -166,7 +153,7 @@ public class RRFRetrieverBuilderTests extends ESTestCase {
     public void testMultiFieldsParamsRewrite() {
         final String indexName = "test-index";
         final List<String> testInferenceFields = List.of("semantic_field_1", "semantic_field_2");
-        final ResolvedIndices resolvedIndices = createMockResolvedIndices(indexName, testInferenceFields, null);
+        final ResolvedIndices resolvedIndices = createMockResolvedIndices(Map.of(indexName, testInferenceFields), null, Map.of());
         final QueryRewriteContext queryRewriteContext = new QueryRewriteContext(
             parserConfig(),
             null,
@@ -250,9 +237,9 @@ public class RRFRetrieverBuilderTests extends ESTestCase {
 
     public void testSearchRemoteIndex() {
         final ResolvedIndices resolvedIndices = createMockResolvedIndices(
-            "local-index",
-            List.of(),
-            Map.of("remote-cluster", "remote-index")
+            Map.of("local-index", List.of()),
+            Map.of("remote-cluster", "remote-index"),
+            Map.of()
         );
         final QueryRewriteContext queryRewriteContext = new QueryRewriteContext(
             parserConfig(),
@@ -303,87 +290,31 @@ public class RRFRetrieverBuilderTests extends ESTestCase {
         return new NamedXContentRegistry(entries);
     }
 
-    private static ResolvedIndices createMockResolvedIndices(
-        String localIndexName,
-        List<String> inferenceFields,
-        Map<String, String> remoteIndexNames
-    ) {
-        Index index = new Index(localIndexName, randomAlphaOfLength(10));
-        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(index.getName())
-            .settings(
-                Settings.builder()
-                    .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
-                    .put(IndexMetadata.SETTING_INDEX_UUID, index.getUUID())
-            )
-            .numberOfShards(1)
-            .numberOfReplicas(0);
-
-        for (String inferenceField : inferenceFields) {
-            indexMetadataBuilder.putInferenceField(
-                new InferenceFieldMetadata(inferenceField, randomAlphaOfLengthBetween(3, 5), new String[] { inferenceField }, null)
-            );
-        }
-
-        Map<String, OriginalIndices> remoteIndices = new HashMap<>();
-        if (remoteIndexNames != null) {
-            for (Map.Entry<String, String> entry : remoteIndexNames.entrySet()) {
-                remoteIndices.put(entry.getKey(), new OriginalIndices(new String[] { entry.getValue() }, IndicesOptions.DEFAULT));
-            }
-        }
-
-        return new MockResolvedIndices(
-            remoteIndices,
-            new OriginalIndices(new String[] { localIndexName }, IndicesOptions.DEFAULT),
-            Map.of(index, indexMetadataBuilder.build())
-        );
-    }
-
-    private static void assertMultiFieldsParamsRewrite(
+    private void assertMultiFieldsParamsRewrite(
         RRFRetrieverBuilder retriever,
         QueryRewriteContext ctx,
         Map<String, Float> expectedNonInferenceFields,
         Map<String, Float> expectedInferenceFields,
         String expectedQuery
     ) {
-        Set<Object> expectedInnerRetrievers = Set.of(
-            CompoundRetrieverBuilder.RetrieverSource.from(
-                new StandardRetrieverBuilder(
-                    new MultiMatchQueryBuilder(expectedQuery).type(MultiMatchQueryBuilder.Type.MOST_FIELDS)
-                        .fields(expectedNonInferenceFields)
-                )
-            ),
-            Set.of(expectedInferenceFields.entrySet().stream().map(e -> {
-                if (e.getValue() != 1.0f) {
-                    throw new IllegalArgumentException("Cannot apply per-field weights in RRF");
-                }
-                return CompoundRetrieverBuilder.RetrieverSource.from(
-                    new StandardRetrieverBuilder(new MatchQueryBuilder(e.getKey(), expectedQuery))
-                );
-            }).toArray())
-        );
-
-        RetrieverBuilder rewritten = retriever.doRewrite(ctx);
-        assertNotSame(retriever, rewritten);
-        assertTrue(rewritten instanceof RRFRetrieverBuilder);
-
-        RRFRetrieverBuilder rewrittenRrf = (RRFRetrieverBuilder) rewritten;
-        assertEquals(retriever.rankWindowSize(), rewrittenRrf.rankWindowSize());
-        assertEquals(retriever.rankConstant(), rewrittenRrf.rankConstant());
-        assertEquals(expectedInnerRetrievers, getInnerRetrieversAsSet(rewrittenRrf));
+        assertMultiFieldsParamsRewrite(retriever, ctx, expectedNonInferenceFields, expectedInferenceFields, expectedQuery, null);
     }
 
-    private static Set<Object> getInnerRetrieversAsSet(RRFRetrieverBuilder retriever) {
-        Set<Object> innerRetrieversSet = new HashSet<>();
-        for (CompoundRetrieverBuilder.RetrieverSource innerRetriever : retriever.innerRetrievers()) {
-            if (innerRetriever.retriever() instanceof RRFRetrieverBuilder innerRrfRetriever) {
-                assertEquals(retriever.rankWindowSize(), innerRrfRetriever.rankWindowSize());
-                assertEquals(retriever.rankConstant(), innerRrfRetriever.rankConstant());
-                innerRetrieversSet.add(getInnerRetrieversAsSet(innerRrfRetriever));
-            } else {
-                innerRetrieversSet.add(innerRetriever);
-            }
-        }
+    @Override
+    protected float[] getWeights(RRFRetrieverBuilder builder) {
+        return builder.weights();
+    }
 
-        return innerRetrieversSet;
+    @Override
+    protected ScoreNormalizer[] getScoreNormalizers(RRFRetrieverBuilder builder) {
+        return null;
+    }
+
+    @Override
+    protected void assertCompoundRetriever(RRFRetrieverBuilder originalRetriever, RetrieverBuilder rewrittenRetriever) {
+        assert (rewrittenRetriever instanceof RRFRetrieverBuilder);
+        RRFRetrieverBuilder actualRetrieverBuilder = (RRFRetrieverBuilder) rewrittenRetriever;
+        assertEquals(originalRetriever.rankWindowSize(), actualRetrieverBuilder.rankWindowSize());
+        assertEquals(originalRetriever.rankConstant(), actualRetrieverBuilder.rankConstant());
     }
 }


### PR DESCRIPTION
### **User description**
Single commit with tree=8c7939c511b854052233c03dc866f469270829d3^{tree}, parent=5ce0c649d6b0ebe7c731eb23157489e8d3c46633. Exact snapshot of upstream PR head. No conflict resolution attempted.


___

### **PR Type**
Tests


___

### **Description**
- Extract common test utilities into abstract base class

- Refactor LinearRetrieverBuilderTests and RRFRetrieverBuilderTests to extend base

- Remove duplicate test helper methods and mock creation logic

- Consolidate retriever assertion patterns across test classes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AbstractRetrieverBuilderTests"] --> B["LinearRetrieverBuilderTests"]
  A --> C["RRFRetrieverBuilderTests"]
  D["Duplicate Methods"] --> A
  B --> E["Cleaner Test Code"]
  C --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AbstractRetrieverBuilderTests.java</strong><dd><code>Add abstract base class for retriever tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/search/retriever/AbstractRetrieverBuilderTests.java

<ul><li>Create new abstract base class for retriever builder tests<br> <li> Extract common mock creation utilities and assertion methods<br> <li> Define abstract methods for subclass-specific implementations<br> <li> Implement shared test logic for multi-field parameter rewrites</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/67/files#diff-b70b3d4562ad256db7fff65bbb9977d19de53ffb5397095ead8e8b32f01732d3">+241/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LinearRetrieverBuilderTests.java</strong><dd><code>Refactor LinearRetrieverBuilderTests to use base class</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/linear/LinearRetrieverBuilderTests.java

<ul><li>Extend AbstractRetrieverBuilderTests instead of ESTestCase<br> <li> Remove duplicate createMockResolvedIndices and assertion methods<br> <li> Implement abstract methods for LinearRetrieverBuilder specifics<br> <li> Clean up imports and reduce code duplication</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/67/files#diff-35447ed4ed91816d6268f3edcb3de48692879a0e31b14526f032d3eff5266cb4">+18/-213</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RRFRetrieverBuilderTests.java</strong><dd><code>Refactor RRFRetrieverBuilderTests to use base class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java

<ul><li>Extend AbstractRetrieverBuilderTests instead of ESTestCase<br> <li> Remove duplicate mock creation and assertion helper methods<br> <li> Implement abstract methods for RRFRetrieverBuilder specifics<br> <li> Update method calls to use inherited utilities</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/67/files#diff-9858909e048101d98b84d85a30c42a90295d9454f96aa205ed8ab321a77fca94">+23/-92</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

