### PR TITLE
Mirror upstream elastic/elasticsearch#134941 for AI review (snapshot of HEAD tree)

### DIFF
--- a/docs/changelog/134941.yaml
+++ b/docs/changelog/134941.yaml
@@ -1,0 +1,6 @@
+pr: 134941
+summary: "DLM: Better `max_age` rollover for tiny retentions"
+area: Data streams
+type: enhancement
+issues:
+ - 130960

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
@@ -124,6 +124,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -1164,6 +1165,53 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
         dataStreamLifecycleService.run(clusterService.state());
         assertBusy(() -> assertThat(clientSeenRequests.size(), is(4)));
         assertThat(((ForceMergeRequest) clientSeenRequests.get(3)).indices().length, is(1));
+    }
+
+    public void testWithTinyRetentions() {
+        final String dataStreamName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        final int numBackingIndices = 1;
+        final int numFailureIndices = 1;
+        final ProjectMetadata.Builder metadataBuilder = ProjectMetadata.builder(randomProjectIdOrDefault());
+        final DataStreamLifecycle dataLifecycle = DataStreamLifecycle.dataLifecycleBuilder()
+            .dataRetention(TimeValue.timeValueDays(1))
+            .build();
+        final DataStreamLifecycle failuresLifecycle = DataStreamLifecycle.failuresLifecycleBuilder()
+            .dataRetention(TimeValue.timeValueHours(12))
+            .build();
+        final DataStream dataStream = createDataStream(
+            metadataBuilder,
+            dataStreamName,
+            numBackingIndices,
+            numFailureIndices,
+            settings(IndexVersion.current()),
+            dataLifecycle,
+            failuresLifecycle,
+            now
+        );
+        metadataBuilder.put(dataStream);
+
+        final ClusterState state = ClusterState.builder(ClusterName.DEFAULT).putProjectMetadata(metadataBuilder).build();
+        dataStreamLifecycleService.run(state);
+
+        assertThat(clientSeenRequests, hasSize(2));
+        assertThat(clientSeenRequests.get(0), instanceOf(RolloverRequest.class));
+        assertThat(clientSeenRequests.get(1), instanceOf(RolloverRequest.class));
+
+        // test main data stream max_age
+        final RolloverRequest rolloverRequest = (RolloverRequest) clientSeenRequests.get(0);
+        assertThat(rolloverRequest.getRolloverTarget(), is(dataStreamName));
+        final RolloverConditions conditions = rolloverRequest.getConditions();
+        assertThat(conditions.getMaxAge(), equalTo(TimeValue.timeValueHours(1))); // 1 day retention -> 1h max_age
+
+        // test failure data stream max_age
+        final RolloverRequest rolloverFailureIndexRequest = (RolloverRequest) clientSeenRequests.get(1);
+        assertThat(
+            rolloverFailureIndexRequest.getRolloverTarget(),
+            is(IndexNameExpressionResolver.combineSelector(dataStreamName, IndexComponentSelector.FAILURES))
+        );
+
+        final RolloverConditions failureStoreConditions = rolloverFailureIndexRequest.getConditions();
+        assertThat(failureStoreConditions.getMaxAge(), equalTo(TimeValue.timeValueHours(1))); // 12h retention -> 1h max_age
     }
 
     public void testDownsampling() throws Exception {

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/270_small_retention.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/270_small_retention.yml
@@ -1,0 +1,53 @@
+---
+teardown:
+  - do:
+     indices.delete_data_stream:
+        name: "tiny-retention-data-stream"
+        ignore: 404
+  - do:
+     indices.delete_index_template:
+        name: "tiny-retention-template"
+        ignore: 404
+
+---
+"Test failure store rollover with tiny retention":
+  - requires:
+      test_runner_features: [ capabilities, allowed_warnings ]
+      reason: "Exposing failures lifecycle config in templates was added in 9.1+"
+      capabilities:
+        - method: GET
+          path: /_data_stream/{target}
+          capabilities: [ 'failure_store.lifecycle' ]
+  - do:
+      indices.put_index_template:
+        name: tiny-retention-template
+        body:
+          index_patterns: [tiny-retention-*]
+          template:
+            settings:
+              index.number_of_replicas: 0
+            lifecycle:
+              data_retention: "1d"
+            data_stream_options:
+              failure_store:
+                enabled: true
+                lifecycle:
+                  data_retention: "12h"
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: tiny-retention-data-stream
+
+  - do:
+      indices.get_data_stream:
+        name: "tiny-retention-data-stream"
+        include_defaults: true
+  - length: { data_streams: 1 }
+  - match: { data_streams.0.name: tiny-retention-data-stream }
+  - match: { data_streams.0.lifecycle.data_retention: "1d" }
+  - match: { data_streams.0.lifecycle.rollover.max_age: "1h [automatic]" }
+  - match: { data_streams.0.failure_store.enabled: true }
+  - match: { data_streams.0.failure_store.lifecycle.enabled: true }
+  - match: { data_streams.0.failure_store.lifecycle.data_retention: "12h" }
+  - match: { data_streams.0.failure_store.lifecycle.rollover.max_age: "1h [automatic]" }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverConfiguration.java
@@ -173,13 +173,17 @@ public class RolloverConfiguration implements Writeable, ToXContentObject {
     /**
      * When max_age is auto we’ll use the following retention dependent heuristics to compute the value of max_age:
      * - If retention is null aka infinite (default), max_age will be 30 days
-     * - If retention is configured to anything lower than 14 days, max_age will be 1 day
-     * - If retention is configured to anything lower than 90 days, max_age will be 7 days
-     * - If retention is configured to anything greater than 90 days, max_age will be 30 days
+     * - If retention is less than or equal to 1 day, max_age will be 1 hour
+     * - If retention is less than or equal to 14 days, max_age will be 1 day
+     * - If retention is less than or equal to 90 days, max_age will be 7 days
+     * - If retention is greater than 90 days, max_age will be 30 days
      */
     static TimeValue evaluateMaxAgeCondition(@Nullable TimeValue retention) {
         if (retention == null) {
             return TimeValue.timeValueDays(30);
+        }
+        if (retention.compareTo(TimeValue.timeValueDays(1)) <= 0) {
+            return TimeValue.timeValueHours(1);
         }
         if (retention.compareTo(TimeValue.timeValueDays(14)) <= 0) {
             return TimeValue.timeValueDays(1);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverConfigurationTests.java
@@ -268,7 +268,11 @@ public class RolloverConfigurationTests extends AbstractWireSerializingTestCase<
         assertThat(RolloverConfiguration.evaluateMaxAgeCondition(TimeValue.timeValueDays(91)), equalTo(TimeValue.timeValueDays(30)));
         assertThat(RolloverConfiguration.evaluateMaxAgeCondition(TimeValue.timeValueDays(90)), equalTo(TimeValue.timeValueDays(7)));
         assertThat(RolloverConfiguration.evaluateMaxAgeCondition(TimeValue.timeValueDays(14)), equalTo(TimeValue.timeValueDays(1)));
-        assertThat(RolloverConfiguration.evaluateMaxAgeCondition(TimeValue.timeValueDays(1)), equalTo(TimeValue.timeValueDays(1)));
+        assertThat(RolloverConfiguration.evaluateMaxAgeCondition(TimeValue.timeValueDays(1)), equalTo(TimeValue.timeValueHours(1)));
+        assertThat(RolloverConfiguration.evaluateMaxAgeCondition(TimeValue.timeValueHours(23)), equalTo(TimeValue.timeValueHours(1)));
+        assertThat(RolloverConfiguration.evaluateMaxAgeCondition(TimeValue.timeValueHours(12)), equalTo(TimeValue.timeValueHours(1)));
+        assertThat(RolloverConfiguration.evaluateMaxAgeCondition(TimeValue.timeValueHours(1)), equalTo(TimeValue.timeValueHours(1)));
+        assertThat(RolloverConfiguration.evaluateMaxAgeCondition(TimeValue.timeValueHours(0)), equalTo(TimeValue.timeValueHours(1)));
     }
 
     public void testToXContent() throws IOException {


### PR DESCRIPTION
### **User description**
Single commit with tree=cdd8ceeee7541f2657e7528f58c5dffd4e5adc2e^{tree}, parent=6a1d6bf45243b971e81384c6edb3d9a44a0580b8. Exact snapshot of upstream PR head. No conflict resolution attempted.


___

### **PR Type**
Enhancement


___

### **Description**
- Improved rollover logic for data streams with tiny retentions

- Added 1-hour max_age for retentions ≤ 1 day

- Enhanced test coverage for small retention scenarios

- Updated documentation with new rollover behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Retention ≤ 1 day"] --> B["max_age = 1 hour"]
  C["Retention ≤ 14 days"] --> D["max_age = 1 day"]
  E["Retention ≤ 90 days"] --> F["max_age = 7 days"]
  G["Retention > 90 days"] --> H["max_age = 30 days"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RolloverConfiguration.java</strong><dd><code>Enhanced rollover logic for tiny retentions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverConfiguration.java

<ul><li>Added new condition for retentions ≤ 1 day to use 1-hour max_age<br> <li> Updated documentation comments with new rollover logic<br> <li> Modified <code>evaluateMaxAgeCondition</code> method to handle tiny retentions</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/70/files#diff-b767eb731cf3fc116753bd7dbd21cf613835a3e4229e0c66d5e50fbbd2541177">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RolloverConfigurationTests.java</strong><dd><code>Added tests for tiny retention rollover</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverConfigurationTests.java

<ul><li>Updated existing test assertion for 1-day retention<br> <li> Added new test cases for sub-day retentions (23h, 12h, 1h, 0h)<br> <li> Verified 1-hour max_age for all tiny retention scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/70/files#diff-54c395fa7fe56b613efd9870a1b21db082a4f9ffe60e28c25a95c75c8fac32f4">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DataStreamLifecycleServiceTests.java</strong><dd><code>Added integration test for tiny retentions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java

<ul><li>Added <code>testWithTinyRetentions</code> method for integration testing<br> <li> Tests both main data stream and failure store rollover behavior<br> <li> Verifies 1-hour max_age for 1-day and 12-hour retentions<br> <li> Added <code>hasSize</code> import for test assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/70/files#diff-ee2a8904fe2a8417396ee811debb54ea9c40c38451348bdf30432e12455ba04f">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>270_small_retention.yml</strong><dd><code>Added REST API test for small retentions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/270_small_retention.yml

<ul><li>Created new YAML REST test for small retention scenarios<br> <li> Tests data stream with 1-day retention and failure store with 12-hour <br>retention<br> <li> Verifies automatic 1-hour max_age rollover configuration<br> <li> Includes proper setup and teardown for test isolation</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/70/files#diff-0f305035b81d80c438a357fece7e1b05c34c81c42d2731ecf9f001c35cf09e02">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>134941.yaml</strong><dd><code>Added changelog entry for enhancement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/changelog/134941.yaml

<ul><li>Added changelog entry for the enhancement<br> <li> Documented improvement to max_age rollover for tiny retentions<br> <li> Referenced related issue #130960</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/70/files#diff-583c6a935317c15aae06c6a5dd2cc5ea9f05e91bc8c6d465c6b9e487fb51d942">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

