### PR TITLE
Mirror upstream elastic/elasticsearch#135212 for AI review (snapshot of HEAD tree)

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/TsdbDataStreamRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/TsdbDataStreamRestIT.java
@@ -436,10 +436,8 @@ public class TsdbDataStreamRestIT extends DisabledSecurityDataStreamTestCase {
             ObjectPath.evaluate(responseBody, "template.settings.index.routing_path"),
             containsInAnyOrder("metricset", "k8s.pod.uid", "pod.labels.*")
         );
-        assertThat(
-            ObjectPath.evaluate(responseBody, "template.settings.index.dimensions"),
-            containsInAnyOrder("metricset", "k8s.pod.uid", "pod.labels.*")
-        );
+        // not supported when using a dynamic template for time_series_dimension
+        assertThat(ObjectPath.evaluate(responseBody, "template.settings.index.dimensions"), nullValue());
         assertThat(ObjectPath.evaluate(responseBody, "overlapping"), empty());
     }
 

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
@@ -525,16 +525,12 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             }
             """;
         Settings result = generateTsdbSettings(mapping, now);
-        assertThat(result.size(), equalTo(INDEX_DIMENSIONS_TSID_OPTIMIZATION_FEATURE_FLAG ? 5 : 4));
+        assertThat(result.size(), equalTo(4));
         assertThat(IndexSettings.MODE.get(result), equalTo(IndexMode.TIME_SERIES));
         assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
         assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
         assertThat(IndexMetadata.INDEX_ROUTING_PATH.get(result), containsInAnyOrder("host.id", "prometheus.labels.*"));
-        if (INDEX_DIMENSIONS_TSID_OPTIMIZATION_FEATURE_FLAG) {
-            assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), containsInAnyOrder("host.id", "prometheus.labels.*"));
-        } else {
-            assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), empty());
-        }
+        assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), empty());
     }
 
     public void testGenerateRoutingPathFromDynamicTemplateWithMultiplePathMatchEntries() throws Exception {
@@ -570,7 +566,7 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             }
             """;
         Settings result = generateTsdbSettings(mapping, now);
-        assertThat(result.size(), equalTo(INDEX_DIMENSIONS_TSID_OPTIMIZATION_FEATURE_FLAG ? 5 : 4));
+        assertThat(result.size(), equalTo(4));
         assertThat(IndexSettings.MODE.get(result), equalTo(IndexMode.TIME_SERIES));
         assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
         assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
@@ -578,14 +574,7 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             IndexMetadata.INDEX_ROUTING_PATH.get(result),
             containsInAnyOrder("host.id", "xprometheus.labels.*", "yprometheus.labels.*")
         );
-        if (INDEX_DIMENSIONS_TSID_OPTIMIZATION_FEATURE_FLAG) {
-            assertThat(
-                IndexMetadata.INDEX_DIMENSIONS.get(result),
-                containsInAnyOrder("host.id", "xprometheus.labels.*", "yprometheus.labels.*")
-            );
-        } else {
-            assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), empty());
-        }
+        assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), empty());
     }
 
     public void testGenerateRoutingPathFromDynamicTemplateWithMultiplePathMatchEntriesMultiFields() throws Exception {
@@ -626,7 +615,7 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             }
             """;
         Settings result = generateTsdbSettings(mapping, now);
-        assertThat(result.size(), equalTo(INDEX_DIMENSIONS_TSID_OPTIMIZATION_FEATURE_FLAG ? 5 : 4));
+        assertThat(result.size(), equalTo(4));
         assertThat(IndexSettings.MODE.get(result), equalTo(IndexMode.TIME_SERIES));
         assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
         assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
@@ -634,14 +623,7 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             IndexMetadata.INDEX_ROUTING_PATH.get(result),
             containsInAnyOrder("host.id", "xprometheus.labels.*", "yprometheus.labels.*")
         );
-        if (INDEX_DIMENSIONS_TSID_OPTIMIZATION_FEATURE_FLAG) {
-            assertThat(
-                IndexMetadata.INDEX_DIMENSIONS.get(result),
-                containsInAnyOrder("host.id", "xprometheus.labels.*", "yprometheus.labels.*")
-            );
-        } else {
-            assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), empty());
-        }
+        assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), empty());
     }
 
     public void testGenerateRoutingPathFromDynamicTemplate_templateWithNoPathMatch() throws Exception {
@@ -686,13 +668,51 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             }
             """;
         Settings result = generateTsdbSettings(mapping, now);
-        assertThat(result.size(), equalTo(INDEX_DIMENSIONS_TSID_OPTIMIZATION_FEATURE_FLAG ? 5 : 4));
+        assertThat(result.size(), equalTo(4));
         assertThat(IndexSettings.MODE.get(result), equalTo(IndexMode.TIME_SERIES));
         assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
         assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
         assertThat(IndexMetadata.INDEX_ROUTING_PATH.get(result), containsInAnyOrder("host.id", "prometheus.labels.*"));
+        assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), empty());
+    }
+
+    public void testGenerateNonDimensionDynamicTemplate() throws Exception {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        String mapping = """
+            {
+                "_doc": {
+                    "dynamic_templates": [
+                        {
+                            "strings_as_keyword": {
+                                "match_mapping_type": "string",
+                                "mapping": {
+                                    "type": "keyword",
+                                    "ignore_above": 1024,
+                                    "time_series_dimension": false
+                                }
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "host.id": {
+                            "type": "keyword",
+                            "time_series_dimension": true
+                        },
+                        "another_field": {
+                            "type": "keyword"
+                        }
+                    }
+                }
+            }
+            """;
+        Settings result = generateTsdbSettings(mapping, now);
+        assertThat(result.size(), equalTo(INDEX_DIMENSIONS_TSID_OPTIMIZATION_FEATURE_FLAG ? 5 : 4));
+        assertThat(IndexSettings.MODE.get(result), equalTo(IndexMode.TIME_SERIES));
+        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
+        assertThat(IndexMetadata.INDEX_ROUTING_PATH.get(result), containsInAnyOrder("host.id"));
         if (INDEX_DIMENSIONS_TSID_OPTIMIZATION_FEATURE_FLAG) {
-            assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), containsInAnyOrder("host.id", "prometheus.labels.*"));
+            assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), containsInAnyOrder("host.id"));
         } else {
             assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), empty());
         }
@@ -742,11 +762,7 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
         Settings result = generateTsdbSettings(mapping, now);
         assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
         assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
-        if (INDEX_DIMENSIONS_TSID_OPTIMIZATION_FEATURE_FLAG) {
-            assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), containsInAnyOrder("host.id", "prometheus.labels.*"));
-        } else {
-            assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), empty());
-        }
+        assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), empty());
     }
 
     public void testGenerateRoutingPathFromPassThroughObject() throws Exception {
@@ -787,6 +803,44 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
         } else {
             assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), empty());
         }
+    }
+
+    public void testDynamicTemplatePrecedence() throws Exception {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        String mapping = """
+            {
+                "_doc": {
+                    "dynamic_templates": [
+                        {
+                            "no_dimension_labels": {
+                                "path_match": "labels.host_ip",
+                                "mapping": {
+                                    "type": "keyword"
+                                }
+                            }
+                        },
+                        {
+                            "labels": {
+                                "path_match": "labels.*",
+                                "mapping": {
+                                    "type": "keyword",
+                                    "time_series_dimension": true
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+            """;
+        Settings result = generateTsdbSettings(mapping, now);
+        assertThat(result.size(), equalTo(4));
+        assertThat(IndexSettings.MODE.get(result), equalTo(IndexMode.TIME_SERIES));
+        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
+        // labels.host_ip is not a dimension because it matches the first template which does not have time_series_dimension:true
+        // we can't use index.dimensions as it would add non-dimension fields to the tsid
+        assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), empty());
+        assertThat(IndexMetadata.INDEX_ROUTING_PATH.get(result), containsInAnyOrder("labels.*"));
     }
 
     public void testAddNewDimension() throws Exception {
@@ -888,7 +942,7 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
                 }
             }
             """;
-        // the new labels.label1 field already matches labels.*, so no change
+        // we don't support index.dimensions with dynamic templates so we'll unset index.dimensions
         Settings result = onUpdateMappings("labels.*", "labels.*", mapping);
         assertThat(result.size(), equalTo(1));
         assertThat(IndexMetadata.INDEX_DIMENSIONS.get(result), empty());


### PR DESCRIPTION
### **User description**
Single commit with tree=d2b174cfb1581cc6bf445eee1962a2a8a9918cb4^{tree}, parent=e89c613dc36998037d5915f79c1cc92e9c249e76. Exact snapshot of upstream PR head. No conflict resolution attempted.


___

### **PR Type**
Bug fix


___

### **Description**
- Disable `index.dimensions` setting when using dynamic templates for time series dimensions

- Update tests to reflect removal of dimensions optimization for dynamic templates

- Add test case for dynamic template precedence handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dynamic Template Detection"] --> B["Check time_series_dimension"]
  B --> C["Disable index.dimensions"]
  C --> D["Use index.routing_path only"]
  D --> E["Prevent TSID corruption"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TsdbDataStreamRestIT.java</strong><dd><code>Update integration test for dimensions setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/TsdbDataStreamRestIT.java

<ul><li>Update test assertion to expect <code>null</code> value for <code>index.dimensions</code><br> <li> Add comment explaining dynamic template limitation</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/72/files#diff-12436860c55ce2edde76202bbb253d84d64d9415c68b50065939426a2ca74d45">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DataStreamIndexSettingsProviderTests.java</strong><dd><code>Update unit tests for dimensions behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java

<ul><li>Update multiple test methods to expect empty <code>index.dimensions</code><br> <li> Add new test for non-dimension dynamic templates<br> <li> Add test for dynamic template precedence scenarios<br> <li> Remove feature flag conditional assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/72/files#diff-5c43019c6b4ea8cc5e922912850f187fe504fce7eb087dd7f7de5497745f99ca">+86/-32</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DataStreamIndexSettingsProvider.java</strong><dd><code>Disable dimensions setting for dynamic templates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java

<ul><li>Always set <code>matchesAllDimensions = false</code> for dynamic templates<br> <li> Add detailed comment explaining precedence issues with dynamic <br>templates<br> <li> Remove simple path match condition check</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/72/files#diff-cf1f7e9936fb6e833d7c34dd59de012a67a5829ac8b12a0e4b3c0fe6e5e98a44">+11/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

