### PR TITLE
Mirror upstream elastic/elasticsearch#134454 for AI review (snapshot of HEAD tree)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/HardcodedEntitlements.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/HardcodedEntitlements.java
@@ -114,7 +114,13 @@ class HardcodedEntitlements {
                     new FilesEntitlement(serverModuleFileDatas)
                 )
             ),
-            new Scope("java.desktop", List.of(new LoadNativeLibrariesEntitlement())),
+            new Scope(
+                "java.desktop",
+                List.of(
+                    new LoadNativeLibrariesEntitlement(),
+                    new ManageThreadsEntitlement() // For sun.java2d.Disposer. TODO: https://elasticco.atlassian.net/browse/ES-12888
+                )
+            ),
             new Scope(
                 "java.xml",
                 List.of(

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -54,7 +54,7 @@ public class PolicyManager {
      */
     static final Logger generalLogger = LogManager.getLogger(PolicyManager.class);
 
-    static final Set<String> MODULES_EXCLUDED_FROM_SYSTEM_MODULES = Set.of("java.desktop", "java.xml");
+    public static final Set<String> MODULES_EXCLUDED_FROM_SYSTEM_MODULES = Set.of("java.desktop", "java.xml");
 
     /**
      * Identifies a particular entitlement {@link Scope} within a {@link Policy}.
@@ -94,7 +94,7 @@ public class PolicyManager {
          * If this kind corresponds to a single component, this is that component's name;
          * otherwise null.
          */
-        final String componentName;
+        public final String componentName;
 
         ComponentKind(String componentName) {
             this.componentName = componentName;

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/bootstrap/HardcodedEntitlementsTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/bootstrap/HardcodedEntitlementsTests.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.bootstrap;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithEntitlementsOnTestCode;
+
+import java.io.ByteArrayInputStream;
+
+import javax.imageio.stream.MemoryCacheImageInputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@WithEntitlementsOnTestCode
+public class HardcodedEntitlementsTests extends ESTestCase {
+
+    /**
+     * The Tika library can do some things we don't ordinarily want to allow.
+     * <p>
+     * Note that {@link MemoryCacheImageInputStream} doesn't even use {@code Disposer} in JDK 26,
+     * so it's an open question how much effort this deserves.
+     */
+    public void testTikaPDF() {
+        new MemoryCacheImageInputStream(new ByteArrayInputStream("test test".getBytes(UTF_8)));
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/TestScopeResolver.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/TestScopeResolver.java
@@ -9,11 +9,14 @@
 
 package org.elasticsearch.bootstrap;
 
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
-import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
+import org.elasticsearch.entitlement.runtime.policy.PolicyManager.PolicyScope;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 
+import java.lang.module.ModuleDescriptor;
+import java.lang.module.ModuleFinder;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
@@ -22,39 +25,78 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toSet;
 import static org.elasticsearch.entitlement.runtime.policy.PolicyManager.ALL_UNNAMED;
 import static org.elasticsearch.entitlement.runtime.policy.PolicyManager.ComponentKind.PLUGIN;
+import static org.elasticsearch.entitlement.runtime.policy.PolicyManager.ComponentKind.SERVER;
+import static org.elasticsearch.entitlement.runtime.policy.PolicyManager.MODULES_EXCLUDED_FROM_SYSTEM_MODULES;
 
-public record TestScopeResolver(Map<String, PolicyManager.PolicyScope> scopeMap) {
+public final class TestScopeResolver {
 
     private static final Logger logger = LogManager.getLogger(TestScopeResolver.class);
+    private final Map<String, PolicyScope> scopeMap;
+    private static final Map<String, PolicyScope> excludedSystemPackageScopes = computeExcludedSystemPackageScopes();
 
-    PolicyManager.PolicyScope getScope(Class<?> callerClass) {
+    public TestScopeResolver(Map<String, PolicyScope> scopeMap) {
+        this.scopeMap = scopeMap;
+    }
+
+    private static Map<String, PolicyScope> computeExcludedSystemPackageScopes() {
+        // Within any one module layer, module names are unique, so we just need the names
+        Set<String> systemModuleNames = ModuleFinder.ofSystem()
+            .findAll()
+            .stream()
+            .map(ref -> ref.descriptor().name())
+            .filter(MODULES_EXCLUDED_FROM_SYSTEM_MODULES::contains)
+            .collect(toSet());
+
+        Map<String, PolicyScope> result = new TreeMap<>();
+        ModuleLayer.boot().modules().stream().filter(m -> systemModuleNames.contains(m.getName())).forEach(m -> {
+            ModuleDescriptor desc = m.getDescriptor();
+            if (desc != null) {
+                desc.packages().forEach(pkg ->
+                // Our component identification logic returns SERVER for these
+                result.put(pkg, new PolicyScope(SERVER, SERVER.componentName, m.getName())));
+            }
+        });
+        return result;
+    }
+
+    public static @Nullable PolicyScope getExcludedSystemPackageScope(Class<?> callerClass) {
+        return excludedSystemPackageScopes.get(callerClass.getPackageName());
+    }
+
+    PolicyScope getScope(Class<?> callerClass) {
         var callerCodeSource = callerClass.getProtectionDomain().getCodeSource();
-        assert callerCodeSource != null;
+        if (callerCodeSource == null) {
+            // This only happens for JDK classes. Furthermore, for trivially allowed modules, we shouldn't even get here.
+            // Hence, this must be an excluded system module, so check for that.
+            return requireNonNull(getExcludedSystemPackageScope(callerClass));
+        }
 
         var location = callerCodeSource.getLocation().toString();
         var scope = scopeMap.get(location);
         if (scope == null) {
             // Special cases for libraries not handled by our automatically-generated scopeMap
             if (callerClass.getPackageName().startsWith("org.bouncycastle")) {
-                scope = new PolicyManager.PolicyScope(PLUGIN, "security", ALL_UNNAMED);
+                scope = new PolicyScope(PLUGIN, "security", ALL_UNNAMED);
                 logger.debug("Assuming bouncycastle is part of the security plugin");
             }
         }
         if (scope == null) {
             logger.warn("Cannot identify a scope for class [{}], location [{}]", callerClass.getName(), location);
-            return PolicyManager.PolicyScope.unknown(location);
+            return PolicyScope.unknown(location);
         }
         return scope;
     }
 
-    public static Function<Class<?>, PolicyManager.PolicyScope> createScopeResolver(
+    public static Function<Class<?>, PolicyScope> createScopeResolver(
         TestBuildInfo serverBuildInfo,
         List<TestBuildInfo> pluginsBuildInfo,
         Set<String> modularPlugins
     ) {
-        Map<String, PolicyManager.PolicyScope> scopeMap = new TreeMap<>(); // Sorted to make it easier to read during debugging
+        Map<String, PolicyScope> scopeMap = new TreeMap<>(); // Sorted to make it easier to read during debugging
         for (var pluginBuildInfo : pluginsBuildInfo) {
             boolean isModular = modularPlugins.contains(pluginBuildInfo.component());
             for (var location : pluginBuildInfo.locations()) {
@@ -66,7 +108,7 @@ public record TestScopeResolver(Map<String, PolicyManager.PolicyScope> scopeMap)
                     String module = isModular ? location.module() : ALL_UNNAMED;
                     scopeMap.put(
                         getCodeSource(codeSource, location.representativeClass()),
-                        PolicyManager.PolicyScope.plugin(pluginBuildInfo.component(), module)
+                        PolicyScope.plugin(pluginBuildInfo.component(), module)
                     );
                 } catch (MalformedURLException e) {
                     throw new IllegalArgumentException("Cannot locate class [" + location.representativeClass() + "]", e);
@@ -81,7 +123,7 @@ public record TestScopeResolver(Map<String, PolicyManager.PolicyScope> scopeMap)
                 continue;
             }
             try {
-                scopeMap.put(getCodeSource(classUrl, location.representativeClass()), PolicyManager.PolicyScope.server(location.module()));
+                scopeMap.put(getCodeSource(classUrl, location.representativeClass()), PolicyScope.server(location.module()));
             } catch (MalformedURLException e) {
                 throw new IllegalArgumentException("Cannot locate class [" + location.representativeClass() + "]", e);
             }

--- a/test/framework/src/main/java/org/elasticsearch/entitlement/runtime/policy/TestPolicyManager.java
+++ b/test/framework/src/main/java/org/elasticsearch/entitlement/runtime/policy/TestPolicyManager.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.entitlement.runtime.policy;
 
+import org.elasticsearch.bootstrap.TestScopeResolver;
 import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.Entitlement;
 import org.elasticsearch.test.ESTestCase;
@@ -97,6 +98,10 @@ public class TestPolicyManager extends PolicyManager {
 
     @Override
     protected boolean isTrustedSystemClass(Class<?> requestingClass) {
+        if (TestScopeResolver.getExcludedSystemPackageScope(requestingClass) != null) {
+            // We don't trust the excluded packages even though they are in system modules
+            return false;
+        }
         ClassLoader loader = requestingClass.getClassLoader();
         return loader == null || loader == ClassLoader.getPlatformClassLoader();
     }


### PR DESCRIPTION
### **User description**
Single commit with tree=135d74b33ba9f1ce2b0e61fa5fb2a39a3763c688^{tree}, parent=41fea9d8a715b1e2ffb668c3cf54c6c9645f0331. Exact snapshot of upstream PR head. No conflict resolution attempted.


___

### **PR Type**
Enhancement


___

### **Description**
- Add ManageThreadsEntitlement to java.desktop module for sun.java2d.Disposer

- Make PolicyManager fields public for better test framework access

- Add test for Tika PDF functionality with entitlements

- Enhance TestScopeResolver with excluded system package handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HardcodedEntitlements"] --> B["java.desktop module"]
  B --> C["ManageThreadsEntitlement"]
  D["PolicyManager"] --> E["Public fields"]
  F["TestScopeResolver"] --> G["Excluded system packages"]
  H["New test"] --> I["Tika PDF functionality"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HardcodedEntitlements.java</strong><dd><code>Add ManageThreadsEntitlement to java.desktop module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/HardcodedEntitlements.java

<ul><li>Add ManageThreadsEntitlement to java.desktop module scope<br> <li> Include TODO comment referencing ES-12888 for sun.java2d.Disposer</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/73/files#diff-7512cb250c99bda26f5352af0e42a89abc481b1b9869978c53720de30e331c44">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PolicyManager.java</strong><dd><code>Make PolicyManager fields public for external access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java

<ul><li>Make MODULES_EXCLUDED_FROM_SYSTEM_MODULES field public<br> <li> Make ComponentKind.componentName field public</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/73/files#diff-00f96c1a4703ca4950b5e506d8fb5fb81758ede1c8da0161cfd39ae3d336e2b5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TestScopeResolver.java</strong><dd><code>Enhance TestScopeResolver with excluded system package support</code></dd></summary>
<hr>

test/framework/src/main/java/org/elasticsearch/bootstrap/TestScopeResolver.java

<ul><li>Convert from record to final class with constructor<br> <li> Add computeExcludedSystemPackageScopes method for system module <br>handling<br> <li> Add getExcludedSystemPackageScope method for excluded package <br>resolution<br> <li> Enhance getScope method to handle null code sources</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/73/files#diff-1387e9e68646192cc83ef347d6c92ed7f619b039b090081d9d91c725f0e2ada9">+52/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TestPolicyManager.java</strong><dd><code>Update TestPolicyManager to handle excluded system packages</code></dd></summary>
<hr>

test/framework/src/main/java/org/elasticsearch/entitlement/runtime/policy/TestPolicyManager.java

<ul><li>Add TestScopeResolver import<br> <li> Override isTrustedSystemClass to handle excluded system packages<br> <li> Add check for excluded system package scope before trusting classes</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/73/files#diff-e687f734db4d93794e3d8c01273aab2b8fbe90a365d867d722c3a70b79bcd4ac">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HardcodedEntitlementsTests.java</strong><dd><code>Add test for Tika PDF entitlements functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/entitlement/src/test/java/org/elasticsearch/entitlement/bootstrap/HardcodedEntitlementsTests.java

<ul><li>Add new test class with @WithEntitlementsOnTestCode annotation<br> <li> Test Tika PDF functionality using MemoryCacheImageInputStream<br> <li> Include documentation about JDK 26 Disposer changes</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/73/files#diff-dc2bc2b53a1044637076861328b2a23d0a52f779079a77da9beafc78003bfb03">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

