### PR TITLE
Mirror upstream elastic/elasticsearch#134980 for AI review (snapshot of HEAD tree)

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -233,7 +233,7 @@ Note, however, that wildcard field patterns will only resolve to fields that eit
 
 ### Limitations
 
-- **Single index**: Multi-field queries currently work with single index searches only
+- **Single index**: Until 9.2, multi-field queries only work with single index searches.
 - **CCS (Cross Cluster Search)**: Multi-field queries do not support remote cluster searches
 
 ### Examples

--- a/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
+++ b/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
@@ -445,13 +445,13 @@ public class RRFRetrieverBuilderTests extends AbstractRetrieverBuilderTests<RRFR
             null
         );
 
-        // Non-default rank window size
+        // Non-default rank window size and non-default rank_constant
         retriever = new RRFRetrieverBuilder(
             null,
             List.of("field_1", "field_2", "semantic_field_1", "semantic_field_2"),
             "foo2",
             DEFAULT_RANK_WINDOW_SIZE * 2,
-            RRFRetrieverBuilder.DEFAULT_RANK_CONSTANT,
+            RRFRetrieverBuilder.DEFAULT_RANK_CONSTANT * 2,
             new float[0]
         );
         assertMultiIndexMultiFieldsParamsRewrite(


### PR DESCRIPTION
### **User description**
Single commit with tree=16aecaca5333692fff65a3d71818c0d6de287e37^{tree}, parent=eb3bc2f2929209461802884ea01f77d3b3fcf96a. Exact snapshot of upstream PR head. No conflict resolution attempted.


___

### **PR Type**
Tests, Documentation


___

### **Description**
- Update RRF retriever test to use non-default rank constant

- Fix documentation about multi-index search limitations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RRF Test"] -- "update rank constant" --> B["Enhanced Test Coverage"]
  C["Documentation"] -- "clarify limitations" --> D["Updated Multi-Index Info"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RRFRetrieverBuilderTests.java</strong><dd><code>Enhanced RRF test with non-default rank constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java

<ul><li>Update test comment to mention both rank window size and rank constant<br> <li> Change rank constant from default to double the default value</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/75/files#diff-9858909e048101d98b84d85a30c42a90295d9454f96aa205ed8ab321a77fca94">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>retrievers.md</strong><dd><code>Updated multi-index search limitation documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/reference/elasticsearch/rest-apis/retrievers.md

<ul><li>Update limitation note to specify version 9.2 for multi-index support<br> <li> Clarify that multi-field queries work with single index until 9.2</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/75/files#diff-5d357b465325d38d915ce93dacfa3fd288bf76d2dfe1659b515d581b080eda64">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

