### PR TITLE
Mirror upstream elastic/elasticsearch#134215 for AI review (snapshot of HEAD tree)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/PreAnalyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/PreAnalyzer.java
@@ -15,31 +15,15 @@ import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-
-import static java.util.Collections.emptyList;
 
 /**
  * This class is part of the planner.  Acts somewhat like a linker, to find the indices and enrich policies referenced by the query.
  */
 public class PreAnalyzer {
 
-    public static class PreAnalysis {
-        public static final PreAnalysis EMPTY = new PreAnalysis(null, emptyList(), emptyList(), emptyList());
-
-        public final IndexMode indexMode;
-        public final List<IndexPattern> indices;
-        public final List<Enrich> enriches;
-        public final List<IndexPattern> lookupIndices;
-
-        public PreAnalysis(IndexMode indexMode, List<IndexPattern> indices, List<Enrich> enriches, List<IndexPattern> lookupIndices) {
-            this.indexMode = indexMode;
-            this.indices = indices;
-            this.enriches = enriches;
-            this.lookupIndices = lookupIndices;
-        }
+    public record PreAnalysis(IndexMode indexMode, IndexPattern index, List<Enrich> enriches, List<IndexPattern> lookupIndices) {
+        public static final PreAnalysis EMPTY = new PreAnalysis(null, null, List.of(), List.of());
     }
 
     public PreAnalysis preAnalyze(LogicalPlan plan) {
@@ -51,18 +35,19 @@ public class PreAnalyzer {
     }
 
     protected PreAnalysis doPreAnalyze(LogicalPlan plan) {
-        Set<IndexPattern> indices = new HashSet<>();
+
+        Holder<IndexMode> indexMode = new Holder<>();
+        Holder<IndexPattern> index = new Holder<>();
 
         List<Enrich> unresolvedEnriches = new ArrayList<>();
         List<IndexPattern> lookupIndices = new ArrayList<>();
 
-        Holder<IndexMode> indexMode = new Holder<>();
         plan.forEachUp(UnresolvedRelation.class, p -> {
             if (p.indexMode() == IndexMode.LOOKUP) {
                 lookupIndices.add(p.indexPattern());
             } else if (indexMode.get() == null || indexMode.get() == p.indexMode()) {
                 indexMode.set(p.indexMode());
-                indices.add(p.indexPattern());
+                index.set(p.indexPattern());
             } else {
                 throw new IllegalStateException("index mode is already set");
             }
@@ -73,7 +58,6 @@ public class PreAnalyzer {
         // mark plan as preAnalyzed (if it were marked, there would be no analysis)
         plan.forEachUp(LogicalPlan::setPreAnalyzed);
 
-        return new PreAnalysis(indexMode.get(), indices.stream().toList(), unresolvedEnriches, lookupIndices);
+        return new PreAnalysis(indexMode.get(), index.get(), unresolvedEnriches, lookupIndices);
     }
-
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java
@@ -322,20 +322,19 @@ public class EsqlCCSUtils {
     public static void initCrossClusterState(
         IndicesExpressionGrouper indicesGrouper,
         XPackLicenseState licenseState,
-        List<IndexPattern> patterns,
+        IndexPattern pattern,
         EsqlExecutionInfo executionInfo
     ) throws ElasticsearchStatusException {
-        if (patterns.isEmpty()) {
+        if (pattern == null) {
             return;
         }
-        assert patterns.size() == 1 : "Only single index pattern is supported";
         try {
             var groupedIndices = indicesGrouper.groupIndices(
                 // indicesGrouper.getConfiguredClusters() might return mutable set that changes as clusters connect or disconnect.
                 // it is copied here so that we have the same resolution when request contains multiple remote cluster patterns with *
                 Set.copyOf(indicesGrouper.getConfiguredClusters()),
                 IndicesOptions.DEFAULT,
-                patterns.getFirst().indexPattern()
+                pattern.indexPattern()
             );
 
             executionInfo.clusterInfoInitializing(true);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -530,18 +530,12 @@ public class CsvTests extends ESTestCase {
 
     private static CsvTestsDataLoader.MultiIndexTestDataset testDatasets(LogicalPlan parsed) {
         var preAnalysis = new PreAnalyzer().preAnalyze(parsed);
-        var indices = preAnalysis.indices;
-        if (indices.isEmpty()) {
-            /*
-             * If the data set doesn't matter we'll just grab one we know works.
-             * Employees is fine.
-             */
+        if (preAnalysis.index() == null) {
+            // If the data set doesn't matter we'll just grab one we know works. Employees is fine.
             return CsvTestsDataLoader.MultiIndexTestDataset.of(CSV_DATASET_MAP.get("employees"));
-        } else if (preAnalysis.indices.size() > 1) {
-            throw new IllegalArgumentException("unexpected index resolution to multiple entries [" + preAnalysis.indices.size() + "]");
         }
 
-        String indexName = indices.getFirst().indexPattern();
+        String indexName = preAnalysis.index().indexPattern();
         List<CsvTestsDataLoader.TestDataset> datasets = new ArrayList<>();
         if (indexName.endsWith("*")) {
             String indexPrefix = indexName.substring(0, indexName.length() - 1);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java
@@ -699,7 +699,7 @@ public class EsqlCCSUtilsTests extends ESTestCase {
 
         // local only search works with any license state
         {
-            var localOnly = List.of(new IndexPattern(EMPTY, randomFrom("idx", "idx1,idx2*")));
+            var localOnly = new IndexPattern(EMPTY, randomFrom("idx", "idx1,idx2*"));
 
             assertLicenseCheckPasses(indicesGrouper, null, localOnly, "");
             for (var mode : License.OperationMode.values()) {
@@ -710,7 +710,7 @@ public class EsqlCCSUtilsTests extends ESTestCase {
 
         // cross-cluster search requires a valid (active, non-expired) enterprise license OR a valid trial license
         {
-            var remote = List.of(new IndexPattern(EMPTY, randomFrom("idx,remote:idx", "idx1,remote:idx2*,remote:logs")));
+            var remote = new IndexPattern(EMPTY, randomFrom("idx,remote:idx", "idx1,remote:idx2*,remote:logs"));
 
             var supportedLicenses = EnumSet.of(License.OperationMode.TRIAL, License.OperationMode.ENTERPRISE);
             var unsupportedLicenses = EnumSet.complementOf(supportedLicenses);
@@ -738,18 +738,18 @@ public class EsqlCCSUtilsTests extends ESTestCase {
     private void assertLicenseCheckPasses(
         TestIndicesExpressionGrouper indicesGrouper,
         XPackLicenseStatus status,
-        List<IndexPattern> patterns,
+        IndexPattern pattern,
         String... expectedRemotes
     ) {
         var executionInfo = new EsqlExecutionInfo(true);
-        initCrossClusterState(indicesGrouper, createLicenseState(status), patterns, executionInfo);
+        initCrossClusterState(indicesGrouper, createLicenseState(status), pattern, executionInfo);
         assertThat(executionInfo.clusterAliases(), containsInAnyOrder(expectedRemotes));
     }
 
     private void assertLicenseCheckFails(
         TestIndicesExpressionGrouper indicesGrouper,
         XPackLicenseStatus licenseStatus,
-        List<IndexPattern> patterns,
+        IndexPattern pattern,
         String expectedErrorMessageSuffix
     ) {
         ElasticsearchStatusException e = expectThrows(
@@ -757,7 +757,7 @@ public class EsqlCCSUtilsTests extends ESTestCase {
             equalTo(
                 "A valid Enterprise license is required to run ES|QL cross-cluster searches. License found: " + expectedErrorMessageSuffix
             ),
-            () -> initCrossClusterState(indicesGrouper, createLicenseState(licenseStatus), patterns, new EsqlExecutionInfo(true))
+            () -> initCrossClusterState(indicesGrouper, createLicenseState(licenseStatus), pattern, new EsqlExecutionInfo(true))
         );
         assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
     }


### PR DESCRIPTION
### **User description**
Single commit with tree=394aaef8034a4e09c6ef307a5ac9ac5d4f1e3f52^{tree}, parent=c05c61d38cdac9c9608d6e8989f1fa7b9ca035cb. Exact snapshot of upstream PR head. No conflict resolution attempted.


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor PreAnalysis to use record and single index

- Simplify index handling from list to single pattern

- Remove multi-index support and related complexity

- Update CCS utilities for single index pattern


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PreAnalysis class"] --> B["PreAnalysis record"]
  C["List<IndexPattern> indices"] --> D["IndexPattern index"]
  E["Multi-index support"] --> F["Single index pattern"]
  G["Complex index handling"] --> H["Simplified logic"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PreAnalyzer.java</strong><dd><code>Convert PreAnalysis to record with single index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/PreAnalyzer.java

<ul><li>Convert <code>PreAnalysis</code> class to record with single index field<br> <li> Replace <code>List<IndexPattern> indices</code> with <code>IndexPattern index</code><br> <li> Simplify index collection logic using <code>Holder<IndexPattern></code><br> <li> Remove <code>HashSet</code> and <code>Set</code> imports, use single index pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/76/files#diff-ec79f9de6d472ada7636e82a8f68bb9cd31bc72baa3fc8c26e8e91779c479b52">+7/-23</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EsqlCCSUtils.java</strong><dd><code>Update CCS utils for single index pattern</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java

<ul><li>Update <code>initCrossClusterState</code> method signature to accept single <br><code>IndexPattern</code><br> <li> Replace list-based index pattern handling with single pattern<br> <li> Remove assertion for single index pattern size<br> <li> Simplify null check for empty patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/76/files#diff-e79fe9bdb3b065608bdd1620a7bf243de352df3bdfb0c0ea6915b8e2650adffc">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EsqlSession.java</strong><dd><code>Simplify session index handling logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java

<ul><li>Update method calls to use record accessor methods<br> <li> Remove multi-index validation and <code>MappingException</code> import<br> <li> Simplify main index pre-analysis logic<br> <li> Remove try-catch block for invalid index resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/76/files#diff-40060e2ec9003953a228c4a03bdc80a301949b0d4e3dccc1978798e33a992a73">+8/-22</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CsvTests.java</strong><dd><code>Update CSV tests for single index pattern</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java

<ul><li>Update test to use single index pattern instead of list<br> <li> Remove multi-index size validation logic<br> <li> Simplify dataset selection based on single index pattern<br> <li> Use record accessor method for index access</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/76/files#diff-4bac7ec76e8fbf4b8960961e9e43d1b826172c92dfe3c6f24c1affdd3732a075">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EsqlCCSUtilsTests.java</strong><dd><code>Update CCS utils tests for single pattern</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java

<ul><li>Update test method signatures to use single <code>IndexPattern</code><br> <li> Replace list creation with direct <code>IndexPattern</code> instantiation<br> <li> Modify assertion helper methods for single pattern handling<br> <li> Update test cases to work with single index pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/76/files#diff-736a05182b9dbcd831c9d27e36068f941293a23fde039b3a1de3ef58ecf1888c">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

