### PR TITLE
Mirror upstream elastic/elasticsearch#134536 for AI review (snapshot of HEAD tree)

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -87,6 +87,7 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
@@ -1393,7 +1394,7 @@ public class DataStreamIT extends ESIntegTestCase {
     public void testGetDataStream() throws Exception {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, maximumNumberOfReplicas() + 2).build();
         DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.dataLifecycleBuilder()
-            .dataRetention(randomPositiveTimeValue())
+            .dataRetention(randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10)))
             .buildTemplate();
         putComposableIndexTemplate("template_for_foo", null, List.of("metrics-foo*"), settings, null, null, lifecycle, false);
         int numDocsFoo = randomIntBetween(2, 16);

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudDataStreamLifecycleIT.java
@@ -227,7 +227,7 @@ public class CrudDataStreamLifecycleIT extends ESIntegTestCase {
 
     public void testDeleteLifecycle() throws Exception {
         DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.dataLifecycleBuilder()
-            .dataRetention(randomPositiveTimeValue())
+            .dataRetention(randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10)))
             .buildTemplate();
         putComposableIndexTemplate("id1", null, List.of("with-lifecycle*"), null, null, lifecycle);
         putComposableIndexTemplate("id2", null, List.of("without-lifecycle*"), null, null, null);

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudSystemDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudSystemDataStreamLifecycleIT.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.datastreams.DataStreamsPlugin;
 import org.elasticsearch.indices.ExecutorNames;
 import org.elasticsearch.indices.SystemDataStreamDescriptor;
@@ -207,7 +208,10 @@ public class CrudSystemDataStreamLifecycleIT extends ESIntegTestCase {
                                 Template.builder()
                                     .settings(Settings.EMPTY)
                                     .mappings(mappings)
-                                    .lifecycle(DataStreamLifecycle.dataLifecycleBuilder().dataRetention(randomPositiveTimeValue()))
+                                    .lifecycle(
+                                        DataStreamLifecycle.dataLifecycleBuilder()
+                                            .dataRetention(randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10)))
+                                    )
                             )
                             .dataStreamTemplate(new DataStreamTemplate())
                             .build(),

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1423,6 +1423,18 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     /**
+     * Generate a random TimeValue that is greater than the provided timeValue.
+     * Chooses a random TimeUnit, adds between 1 and 1000 of that unit to {@code timeValue}, and returns a TimeValue in that unit.
+     */
+    public static TimeValue randomTimeValueGreaterThan(TimeValue lowerBound) {
+        final TimeUnit randomUnit = randomFrom(TimeUnit.values());
+        // This conversion might round down, but that's fine since we add at least 1 below, ensuring we still satisfy the "greater than".
+        final long lowerBoundDuration = randomUnit.convert(lowerBound.duration(), lowerBound.timeUnit());
+        final long duration = lowerBoundDuration + randomLongBetween(1, 1000);
+        return new TimeValue(duration, randomUnit);
+    }
+
+    /**
      * generate a random epoch millis in a range 1 to 9999-12-31T23:59:59.999
      */
     public static long randomMillisUpToYear9999() {

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataStreamAndIndexLifecycleMixingTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataStreamAndIndexLifecycleMixingTests.java
@@ -152,18 +152,15 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
 
         // let's update the index template to remove the ILM configuration and configured data stream lifecycle
         // note that this index template change will NOT configure a data stream lifecycle on the data stream, only for **new** data streams
-
         // All existing data streams will fallback to their default data stream lifecycle
-
-        // we'll rollover the data stream by indexing 2 documents (like ILM expects) and assert that the rollover happens once so the
-        // data stream has 3 backing indices, two managed by ILM and one will be managed by the data stream lifecycle
         DataStreamLifecycle.Template customLifecycle = DataStreamLifecycle.dataLifecycleBuilder()
-            .dataRetention(randomPositiveTimeValue())
+            .dataRetention(randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10)))
             .buildTemplate();
         putComposableIndexTemplate(indexTemplateName, null, List.of(dataStreamName + "*"), Settings.EMPTY, null, customLifecycle);
 
+        // we'll rollover the data stream by indexing 2 documents (like ILM expects) and assert that the rollover happens once so the
+        // data stream has 3 backing indices, two managed by ILM and one will be managed by the data stream lifecycle
         indexDocs(dataStreamName, 2);
-
         // data stream was rolled over and has 3 indices, two managed by ILM and the write index will be unmanaged
         backingIndices = waitForDataStreamBackingIndices(dataStreamName, 3);
         String thirdGenerationIndex = backingIndices.get(2);
@@ -482,11 +479,8 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
 
         // let's update the index template to configure the management preference to be data stream lifecycle using the prefer_ilm setting
         // note that this index template change will NOT affect existing indices but only the new ones after a rollover.
-
-        // we'll rollover the data stream by indexing 2 documents (like ILM expects) and assert that the rollover happens once so the
-        // data stream has 3 backing indices, 2 managed by ILM and 1 by the default data stream lifecycle
         DataStreamLifecycle.Template customLifecycle = DataStreamLifecycle.dataLifecycleBuilder()
-            .dataRetention(randomPositiveTimeValue())
+            .dataRetention(randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10)))
             .buildTemplate();
         putComposableIndexTemplate(
             indexTemplateName,
@@ -497,8 +491,9 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
             customLifecycle
         );
 
+        // we'll rollover the data stream by indexing 2 documents (like ILM expects) and assert that the rollover happens once so the
+        // data stream has 3 backing indices, 2 managed by ILM and 1 by the default data stream lifecycle
         indexDocs(dataStreamName, 2);
-
         backingIndices = waitForDataStreamBackingIndices(dataStreamName, 3);
         String thirdGenerationIndex = backingIndices.get(2);
 


### PR DESCRIPTION
### **User description**
Single commit with tree=7e65b8046c73a56be09fd73a67cffc5647c2ca88^{tree}, parent=73c74fbb0ca2f2f933ff4287920ed3b977b0693d. Exact snapshot of upstream PR head. No conflict resolution attempted.


___

### **PR Type**
Tests


___

### **Description**
- Replace `randomPositiveTimeValue()` with `randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10))`

- Add new test utility method for generating time values above threshold

- Update data stream lifecycle tests to use minimum retention period

- Minor code formatting improvements in test files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["randomPositiveTimeValue()"] -- "replaced with" --> B["randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10))"]
  C["ESTestCase"] -- "adds new method" --> B
  B -- "used in" --> D["Data Stream Tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DataStreamIT.java</strong><dd><code>Update random time value generation method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java

<ul><li>Import <code>TimeValue</code> class<br> <li> Replace <code>randomPositiveTimeValue()</code> with <br><code>randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10))</code></ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/85/files#diff-bd4357c93769ccd3a130cf3540210d91d7294ab6a66a672d41fa945e46562501">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CrudDataStreamLifecycleIT.java</strong><dd><code>Update lifecycle test time value generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudDataStreamLifecycleIT.java

<ul><li>Replace <code>randomPositiveTimeValue()</code> with <br><code>randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10))</code></ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/85/files#diff-1ad6e57a611f01dddbda68d891641393469be0ab54cb6e66152ad1d2f80b62eb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CrudSystemDataStreamLifecycleIT.java</strong><dd><code>Update system data stream lifecycle test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudSystemDataStreamLifecycleIT.java

<ul><li>Import <code>TimeValue</code> class<br> <li> Replace <code>randomPositiveTimeValue()</code> with <br><code>randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10))</code><br> <li> Reformat lifecycle builder call for better readability</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/85/files#diff-017c90ea5f933a32ee1c18252bde112c3b873488bf5e53a239f92c9c57f9d00b">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DataStreamAndIndexLifecycleMixingTests.java</strong><dd><code>Update ILM mixing tests and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataStreamAndIndexLifecycleMixingTests.java

<ul><li>Replace <code>randomPositiveTimeValue()</code> with <br><code>randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10))</code><br> <li> Remove excessive blank lines and reorganize comments<br> <li> Improve code formatting and readability</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/85/files#diff-47c2f9caca11c9c24c832cf91b9992a49650ea7dce2cef3efc70324989f281d0">+6/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ESTestCase.java</strong><dd><code>Add randomTimeValueGreaterThan utility method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java

<ul><li>Add new <code>randomTimeValueGreaterThan(TimeValue lowerBound)</code> method<br> <li> Method generates random TimeValue greater than provided lower bound<br> <li> Includes comprehensive JavaDoc documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/phananh1010/elasticsearch/pull/85/files#diff-4775cf1e524e3d7085511b07a0119726841f6e4566a66cc317617004e7a1cb1b">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated data retention settings in data stream and lifecycle tests to ensure durations exceed 10 seconds, improving timing reliability.
  * Added a helper to generate random time values above a specified lower bound, reducing flakiness in timing-sensitive scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->