### PR TITLE
Mirror upstream elastic/elasticsearch#134980 for AI review (snapshot of HEAD tree)

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -233,7 +233,7 @@ Note, however, that wildcard field patterns will only resolve to fields that eit
 
 ### Limitations
 
-- **Single index**: Multi-field queries currently work with single index searches only
+- **Single index**: Until 9.2, multi-field queries only work with single index searches.
 - **CCS (Cross Cluster Search)**: Multi-field queries do not support remote cluster searches
 
 ### Examples

--- a/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
+++ b/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
@@ -445,13 +445,13 @@ public class RRFRetrieverBuilderTests extends AbstractRetrieverBuilderTests<RRFR
             null
         );
 
-        // Non-default rank window size
+        // Non-default rank window size and non-default rank_constant
         retriever = new RRFRetrieverBuilder(
             null,
             List.of("field_1", "field_2", "semantic_field_1", "semantic_field_2"),
             "foo2",
             DEFAULT_RANK_WINDOW_SIZE * 2,
-            RRFRetrieverBuilder.DEFAULT_RANK_CONSTANT,
+            RRFRetrieverBuilder.DEFAULT_RANK_CONSTANT * 2,
             new float[0]
         );
         assertMultiIndexMultiFieldsParamsRewrite(


### PR DESCRIPTION
Single commit with tree=16aecaca5333692fff65a3d71818c0d6de287e37^{tree}, parent=eb3bc2f2929209461802884ea01f77d3b3fcf96a. Exact snapshot of upstream PR head. No conflict resolution attempted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Restored the “Linear retriever with the multi-field query format” example in the retrievers documentation.
- Documentation
  - Clarified limitation: Until 9.2, multi-field queries only work with single-index searches.
  - Updated examples list to reflect available multi-field query usage.
- Tests
  - Updated RRF retriever tests to cover non-default ranking parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->