### PR TITLE
Mirror upstream elastic/elasticsearch#134413 for AI review (snapshot of HEAD tree)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tsdb-mapping.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tsdb-mapping.json
@@ -10,6 +10,10 @@
     "name": {
       "type": "keyword"
     },
+    "host": {
+      "type": "keyword",
+      "time_series_dimension": true
+    },
     "network": {
       "properties": {
         "connections": {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
@@ -10,7 +10,6 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
 import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
 import org.elasticsearch.xpack.esql.common.Failures;
@@ -29,7 +28,6 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.FilteredExpression;
-import org.elasticsearch.xpack.esql.expression.function.aggregate.Rate;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.TimeSeriesAggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.fulltext.FullTextFunction;
 import org.elasticsearch.xpack.esql.expression.function.grouping.Categorize;
@@ -243,16 +241,16 @@ public class Aggregate extends UnaryPlan
             // traverse the tree to find invalid matches
             checkInvalidNamedExpressionUsage(exp, groupings, groupRefs, failures, 0);
         });
-        if (anyMatch(l -> l instanceof EsRelation relation && relation.indexMode() == IndexMode.TIME_SERIES)) {
-            aggregates.forEach(a -> checkRateAggregates(a, 0, failures));
-        } else {
-            forEachExpression(
-                TimeSeriesAggregateFunction.class,
-                r -> failures.add(fail(r, "time_series aggregate[{}] can only be used with the TS command", r.sourceText()))
-            );
-        }
+        checkTimeSeriesAggregates(failures);
         checkCategorizeGrouping(failures);
         checkMultipleScoreAggregations(failures);
+    }
+
+    protected void checkTimeSeriesAggregates(Failures failures) {
+        forEachExpression(
+            TimeSeriesAggregateFunction.class,
+            r -> failures.add(fail(r, "time_series aggregate[{}] can only be used with the TS command", r.sourceText()))
+        );
     }
 
     private void checkMultipleScoreAggregations(Failures failures) {
@@ -351,22 +349,6 @@ public class Aggregate extends UnaryPlan
                 );
             }
         })));
-    }
-
-    private static void checkRateAggregates(Expression expr, int nestedLevel, Failures failures) {
-        if (expr instanceof AggregateFunction) {
-            nestedLevel++;
-        }
-        if (expr instanceof Rate r) {
-            if (nestedLevel != 2) {
-                failures.add(
-                    fail(expr, "the rate aggregate [{}] can only be used with the TS command and inside another aggregate", r.sourceText())
-                );
-            }
-        }
-        for (Expression child : expr.children()) {
-            checkRateAggregates(child, nestedLevel, failures);
-        }
     }
 
     // traverse the expression and look either for an agg function or a grouping match


### PR DESCRIPTION
Single commit with tree=69b95e47c4d65a8c6903b6f532b08d03d5406360^{tree}, parent=3c3058e6f63c5ebdcc4513fc5dcc4ffb3ec8a752. Exact snapshot of upstream PR head. No conflict resolution attempted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for “host” as a time-series dimension, enabling more granular filtering and aggregation.
* Bug Fixes
  * Enforced correct usage of time-series aggregate functions, including disallowing COUNT(*) with time-series aggregation where invalid.
  * Blocked unsupported operations (e.g., sorting, limiting, certain joins) between a time-series source and the first aggregation, and between chained aggregations.
  * Improved and standardized error messages for time-series aggregation misuse.
* Tests
  * Expanded test coverage for time-series aggregation rules, sorting/limiting constraints, and updated expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->