### PR TITLE
Mirror upstream elastic/elasticsearch#134737 for AI review (snapshot of HEAD tree)

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportDataStreamsStatsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportDataStreamsStatsAction.java
@@ -106,7 +106,7 @@ public class TransportDataStreamsStatsAction extends TransportBroadcastByNodeAct
 
     @Override
     protected ShardsIterator shards(ClusterState clusterState, DataStreamsStatsAction.Request request, String[] concreteIndices) {
-        return clusterState.routingTable(projectResolver.getProjectId()).allShards(concreteIndices);
+        return clusterState.routingTable(projectResolver.getProjectId()).allSearchableShards(concreteIndices);
     }
 
     @Override
@@ -117,6 +117,7 @@ public class TransportDataStreamsStatsAction extends TransportBroadcastByNodeAct
         ActionListener<DataStreamsStatsAction.DataStreamShardStats> listener
     ) {
         ActionListener.completeWith(listener, () -> {
+            assert shardRouting.isSearchable() : "shard routing is not searchable: " + shardRouting;
             IndexService indexService = indicesService.indexServiceSafe(shardRouting.shardId().getIndex());
             IndexShard indexShard = indexService.getShard(shardRouting.shardId().id());
             StoreStats storeStats = indexShard.storeStats();

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/120_data_streams_stats.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/120_data_streams_stats.yml
@@ -8,9 +8,6 @@ setup:
         name: my-template1
         body:
           index_patterns: [simple-data-stream1]
-          template:
-            settings:
-              index.number_of_replicas: 0
           data_stream: {}
   - do:
       allowed_warnings:
@@ -19,9 +16,6 @@ setup:
         name: my-template2
         body:
           index_patterns: [simple-data-stream2]
-          template:
-            settings:
-              index.number_of_replicas: 0
           data_stream: {}
 
 ---
@@ -50,6 +44,10 @@ setup:
   - do:
       indices.rollover:
         alias: "simple-data-stream1"
+
+  - do:
+      cluster.health:
+        wait_for_no_initializing_shards: true
 
   - do:
       indices.data_streams_stats: {}
@@ -195,8 +193,8 @@ setup:
 
   - do:
       indices.data_streams_stats: {}
-  - match: { _shards.total: 3 }
-  - match: { _shards.successful: 3 }
+  - match: { _shards.total: 6 }
+  - match: { _shards.successful: 6 }
   - match: { _shards.failed: 0 }
   - match: { data_stream_count: 2 }
   - match: { backing_indices: 3 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -242,6 +242,13 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         return allShardsSatisfyingPredicate(indices, Predicates.always(), false);
     }
 
+    /**
+     * Returns an iterator over all shard routing entries that are searchable (i.e., on a node that can service searches).
+     */
+    public ShardsIterator allSearchableShards(String[] indices) {
+        return allShardsSatisfyingPredicate(indices, ShardRouting::isSearchable, false);
+    }
+
     public ShardsIterator allActiveShards(String[] indices) {
         return allShardsSatisfyingPredicate(indices, ShardRouting::active, false);
     }


### PR DESCRIPTION
Single commit with tree=cbc3bd29965ad662ee9aa3d6e9c4177bc8c64fa0^{tree}, parent=622ff24947bf7211a02057220fd40ded027040b3. Exact snapshot of upstream PR head. No conflict resolution attempted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Data stream stats now consider only searchable shards, preventing errors from unsearchable shards and improving accuracy of shard-related metrics.
- Improvements
  - More reliable shard counting in data stream stats, reflecting the actual set of searchable shards.
  - Enhanced runtime safeguards to ensure shard eligibility before stats collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->