### PR TITLE
Mirror upstream elastic/elasticsearch#134118 for AI review (snapshot of HEAD tree)

### DIFF
--- a/.buildkite/pipelines/java-ea-check-new-build.yml
+++ b/.buildkite/pipelines/java-ea-check-new-build.yml
@@ -1,0 +1,7 @@
+steps:
+  - command: .buildkite/scripts/trigger-if-java-ea-new-build.sh
+    env:
+      RECENT_TIME_WINDOW: "24" # time window to consider a build as new in hours
+    agents:
+      image: "docker.elastic.co/ci-agent-images/eck-region/buildkite-agent:1.5"
+      memory: "4G"

--- a/.buildkite/scripts/trigger-if-java-ea-new-build.sh
+++ b/.buildkite/scripts/trigger-if-java-ea-new-build.sh
@@ -1,0 +1,95 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the "Elastic License
+# 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+# Public License v 1"; you may not use this file except in compliance with, at
+# your election, the "Elastic License 2.0", the "GNU Affero General Public
+# License v3.0 only", or the "Server Side Public License, v 1".
+#
+
+#!/bin/bash
+
+# Allow overriding the time window (in hours) to check for new builds, defaults to 24
+RECENT_TIME_WINDOW=${RECENT_TIME_WINDOW:-24}
+
+# Extract current JDK major version from bundled_jdk in version.properties
+CURRENT_JDK=$(grep "^bundled_jdk =" build-tools-internal/version.properties | cut -d'=' -f2 | tr -d ' ' | cut -d'.' -f1)
+TARGET_JDK=$((CURRENT_JDK + 1))
+
+echo "Current JDK major version: $CURRENT_JDK"
+echo "Target JDK major version: $TARGET_JDK"
+
+# Query Elasticsearch JDK archive for available JDKs
+JDK_ARCHIVE_URL="https://builds.es-jdk-archive.com/jdks/openjdk/recent.json"
+echo "Querying JDK archive: $JDK_ARCHIVE_URL"
+
+# Fetch JDK info and filter for target major version
+JDK_DATA=$(curl -s "$JDK_ARCHIVE_URL")
+
+if [[ -z "$JDK_DATA" ]]; then
+  echo "Failed to fetch JDK data from archive"
+  exit 1
+fi
+
+# Find the latest build for the target JDK version
+LATEST_BUILD=$(echo "$JDK_DATA" | jq -r --arg target "$TARGET_JDK" '
+  .majors[$target].builds |
+  sort_by(.archived_at) |
+  last'
+)
+
+if [[ "$LATEST_BUILD" == "null" || -z "$LATEST_BUILD" ]]; then
+  echo "No builds found for JDK $TARGET_JDK"
+  exit 1
+fi
+
+# Extract timestamp and JDK identifier
+TIMESTAMP=$(echo "$LATEST_BUILD" | jq -r '.archived_at')
+JDK_IDENTIFIER=$(echo "$LATEST_BUILD" | jq -r '.id')
+
+echo "Latest JDK ${TARGET_JDK} build from ES archive:"
+echo "  Timestamp: $TIMESTAMP"
+echo "  JDK Identifier: $JDK_IDENTIFIER"
+
+# Set variables for use in the pipeline trigger
+jdkbuild="$JDK_IDENTIFIER"
+jdk_timestamp="$TIMESTAMP"
+
+# Check if timestamp is within last 24 hours
+CURRENT_TIME=$(date +%s)
+BUILD_TIME=$(date -d "$TIMESTAMP" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%S" "${TIMESTAMP%Z}" +%s 2>/dev/null || echo "0")
+
+if [[ "$BUILD_TIME" == "0" ]]; then
+  echo "Failed to parse timestamp: $TIMESTAMP"
+  SHOULD_TRIGGER="false"
+else
+  TIME_DIFF=$((CURRENT_TIME - BUILD_TIME))
+  TIME_WINDOW=$((RECENT_TIME_WINDOW * 60 * 60))
+
+  if [[ $TIME_DIFF -lt $TIME_WINDOW ]]; then
+    echo "Build is recent (less than ${RECENT_TIME_WINDOW}h old)"
+    SHOULD_TRIGGER="true"
+  else
+    echo "Build is older than ${RECENT_TIME_WINDOW} hours"
+    SHOULD_TRIGGER="false"
+  fi
+fi
+
+echo "SHOULD_TRIGGER: $SHOULD_TRIGGER"
+
+
+if [[ "$SHOULD_TRIGGER" == "true" ]]; then
+  EFFECTIVE_START_DATE=$(date -u -d "@$BUILD_TIME" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -r "$BUILD_TIME" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
+  echo "Triggering performance-esbench-jdk for new jdk build $JDK_IDENTIFIER"
+  cat << EOF | buildkite-agent pipeline upload
+steps:
+- trigger: elasticsearch-performance-esbench-jdk
+  label: Triggering performance-esbench-jdk for new jdk build $JDK_IDENTIFIER
+  async: true
+  build:
+    branch: "$BUILDKITE_BRANCH"
+    env:
+      EFFECTIVE_START_DATE: "$EFFECTIVE_START_DATE"
+      EXECUTION_MODE: "start-run"
+EOF
+fi

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -138,7 +138,45 @@ spec:
           cronline: "0 4 * * * America/New_York"
           message: "Run java EA tests 1x per day"
 ---
-
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elasticsearch-java-ea-check-new-build
+  description: Check for new jdk ea build and trigger downstream jobs
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elasticsearch-java-ea-check-new-build
+spec:
+  type: buildkite-pipeline
+  system: buildkite
+  owner: group:elasticsearch-team
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: ":java: Check for new pre release jdk build and trigger downstream jobs"
+      name: elasticsearch / java-ea / check-new-build
+    spec:
+      repository: elastic/elasticsearch
+      pipeline_file: .buildkite/pipelines/java-ea-check-new-build.yml
+      branch_configuration: main
+      teams:
+        elasticsearch-team: {}
+        ml-core: {}
+        everyone:
+          access_level: BUILD_AND_READ
+      provider_settings:
+        build_branches: false
+        build_pull_requests: false
+        publish_commit_status: false
+        trigger_mode: none
+      schedules:
+        Periodically on main:
+          branch: main
+          cronline: "0 6 * * * UTC"
+          message: "Check for new java pre release build 1x per day"
+---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource


### PR DESCRIPTION
Single commit with tree=35b2a6eb6099dae4c3480474460ebb8a1a9d01f7^{tree}, parent=3eefef7fd007602714ba786e20d58847ec9b1561. Exact snapshot of upstream PR head. No conflict resolution attempted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automated daily check for new Java Early Access builds that triggers the performance pipeline when a recent build is detected.
- Chores
  - Configured a 24-hour detection window, runtime constraints, and environment parameters for the automated trigger.
  - Scheduled the job to run at 06:00 UTC on the main branch.
  - Registered the pipeline in the internal catalog for visibility and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->