### PR TITLE
Mirror upstream elastic/elasticsearch#134403 for AI review (snapshot of HEAD tree)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-avg-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-avg-over-time.csv-spec
@@ -100,6 +100,22 @@ tx:double          | cluster:keyword | time_bucket:datetime
 493.5              | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+avg_over_time_with_inline_filtering
+required_capability: metrics_command
+TS k8s | STATS tx = sum(avg_over_time(network.bytes_in)) WHERE pod == "one"  BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
+
+tx:double          | cluster:keyword | time_bucket:datetime
+293.0              | prod            | 2024-05-10T00:00:00.000Z
+482.6666666666667  | qa              | 2024-05-10T00:00:00.000Z
+494.1666666666667  | staging         | 2024-05-10T00:00:00.000Z
+601.5454545454545  | prod            | 2024-05-10T00:10:00.000Z
+496.14285714285717 | qa              | 2024-05-10T00:10:00.000Z
+441.6              | staging         | 2024-05-10T00:10:00.000Z
+633.3333333333334  | prod            | 2024-05-10T00:20:00.000Z
+440.0              | qa              | 2024-05-10T00:20:00.000Z
+493.5              | staging         | 2024-05-10T00:20:00.000Z
+;
+
 avg_over_time_older_than_10d
 required_capability: metrics_command
 required_capability: avg_over_time

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-last-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-last-over-time.csv-spec
@@ -106,6 +106,24 @@ tx:long | cluster:keyword | time_bucket:datetime
 238     | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+implicit_last_over_time_with_inline_filtering
+required_capability: metrics_command
+required_capability: implicit_last_over_time
+TS k8s  | STATS tx = sum(network.bytes_in) WHERE pod == "one" BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
+
+tx:long | cluster:keyword | time_bucket:datetime
+3       | prod            | 2024-05-10T00:00:00.000Z
+830     | qa              | 2024-05-10T00:00:00.000Z
+753     | staging         | 2024-05-10T00:00:00.000Z
+542     | prod            | 2024-05-10T00:10:00.000Z
+187     | qa              | 2024-05-10T00:10:00.000Z
+4       | staging         | 2024-05-10T00:10:00.000Z
+931     | prod            | 2024-05-10T00:20:00.000Z
+206     | qa              | 2024-05-10T00:20:00.000Z
+238     | staging         | 2024-05-10T00:20:00.000Z
+;
+
+
 
 last_over_time_older_than_10d
 required_capability: metrics_command

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
@@ -73,7 +73,24 @@ rate_bytes_in:double | cluster:keyword | time_bucket:datetime
 2.210158359293873    | prod            | 2024-05-10T00:20:00.000Z
 0.8955555555555565   | qa              | 2024-05-10T00:20:00.000Z
 0.595                | staging         | 2024-05-10T00:20:00.000Z
+;
 
+rate_with_inline_filtering
+required_capability: metrics_command
+TS k8s 
+| STATS rate_bytes_in = sum(rate(network.total_bytes_in)) WHERE pod == "one" BY cluster, time_bucket = bucket(@timestamp, 10minute)
+| SORT time_bucket, cluster | LIMIT 10;
+
+rate_bytes_in:double | cluster:keyword | time_bucket:datetime
+4.0314581958195825   | prod            | 2024-05-10T00:00:00.000Z
+9.955833333333333    | qa              | 2024-05-10T00:00:00.000Z
+4.242445473251029    | staging         | 2024-05-10T00:00:00.000Z
+11.188380281690138   | prod            | 2024-05-10T00:10:00.000Z
+12.222592592592592   | qa              | 2024-05-10T00:10:00.000Z
+3.050371490280777    | staging         | 2024-05-10T00:10:00.000Z
+2.210158359293873    | prod            | 2024-05-10T00:20:00.000Z
+0.8955555555555565   | qa              | 2024-05-10T00:20:00.000Z
+0.595                | staging         | 2024-05-10T00:20:00.000Z
 ;
 
 eval_on_rate

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
@@ -201,6 +201,24 @@ max(rate(network.total_bytes_in)):double | time_bucket:datetime     | cluster:ke
 11.562737642585551                       | 2024-05-10T00:10:00.000Z | prod
 ;
 
+maxRateWithInlineFilter
+required_capability: metrics_command
+TS k8s | STATS max_rate = max(rate(network.total_bytes_in)) WHERE cluster=="prod" BY cluster | SORT cluster;
+
+max_rate:double         | cluster:keyword
+8.716707021791768       | prod
+null                    | qa
+null                    | staging
+;
+
+maxRateWithPreFilter
+required_capability: metrics_command
+TS k8s | WHERE cluster=="prod" | STATS max_rate = max(rate(network.total_bytes_in)) BY cluster | SORT cluster;
+
+max_rate:double         | cluster:keyword
+8.716707021791768       | prod
+;
+
 notEnoughSamples
 required_capability: metrics_command
 TS k8s | WHERE @timestamp <= "2024-05-10T00:06:14.000Z" | STATS max(rate(network.total_bytes_in)) BY pod, time_bucket = bucket(@timestamp,1minute) | SORT pod, time_bucket DESC | LIMIT 10;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunction.java
@@ -11,7 +11,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.capabilities.PostAnalysisPlanVerificationAware;
 import org.elasticsearch.xpack.esql.common.Failures;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
@@ -150,6 +152,17 @@ public abstract class AggregateFunction extends Function implements PostAnalysis
             return this;
         }
         return (AggregateFunction) replaceChildren(CollectionUtils.combine(asList(field, filter), parameters));
+    }
+
+    /**
+     * Returns the set of input attributes required by this aggregate function, excluding those referenced by the filter.
+     */
+    public AttributeSet aggregateInputReferences() {
+        if (hasFilter()) {
+            return Expressions.references(CollectionUtils.combine(List.of(field), parameters));
+        } else {
+            return references();
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -279,7 +279,7 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
                             }
                         } else {
                             // extra dependencies like TS ones (that require a timestamp)
-                            for (Expression input : aggregateFunction.references()) {
+                            for (Expression input : aggregateFunction.aggregateInputReferences()) {
                                 Attribute attr = Expressions.attribute(input);
                                 if (attr == null) {
                                     throw new EsqlIllegalArgumentException(


### PR DESCRIPTION
Single commit with tree=e0ea2b27d76abbbfcea041510f9d0104fabacbbb^{tree}, parent=3e8b3083600c067b496defb7fcd39e8ea6e7852c. Exact snapshot of upstream PR head. No conflict resolution attempted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for inline WHERE filters within time-series aggregate functions (avg_over_time, last_over_time, rate, max_rate) in metrics queries.
  - Inline-filtered aggregates now behave equivalently to pre-filtered forms, preserving outputs and headers across time-bucket groupings.
  - Improves consistency and validation of filter application within nested time-series aggregations, ensuring expected results when filters are placed inside aggregate expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->