### PR TITLE
Mirror upstream elastic/elasticsearch#134347 for AI review (snapshot of HEAD tree)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -516,9 +516,6 @@ tests:
 - class: org.elasticsearch.action.support.nodes.TransportNodesActionTests
   method: testConcurrentlyCompletionAndCancellation
   issue: https://github.com/elastic/elasticsearch/issues/134277
-- class: org.elasticsearch.xpack.core.datastreams.TimeSeriesFeatureSetUsageTests
-  method: testEqualsAndHashcode
-  issue: https://github.com/elastic/elasticsearch/issues/134332
 
 # Examples:
 #

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/TimeSeriesFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/TimeSeriesFeatureSetUsage.java
@@ -34,8 +34,8 @@ import java.util.Objects;
  *   "time_series": {
  *      "enabled": true,
  *      "available": true,
- *      "data_streams_count": 10,
- *      "indices_count": 100,
+ *      "data_stream_count": 10,
+ *      "index_count": 100,
  *      "downsampling": {
  *         "index_count_per_interval": {
  *           "5m": 5,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/TimeSeriesFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/TimeSeriesFeatureSetUsageTests.java
@@ -57,7 +57,7 @@ public class TimeSeriesFeatureSetUsageTests extends AbstractWireSerializingTestC
         var dataStreamCount = instance.getTimeSeriesDataStreamCount();
         if (dataStreamCount == 0) {
             return new TimeSeriesFeatureSetUsage(
-                randomIntBetween(0, 100),
+                randomIntBetween(1, 100),
                 randomIntBetween(100, 100000),
                 TimeSeriesFeatureSetUsage.DownsamplingFeatureStats.EMPTY,
                 Map.of()


### PR DESCRIPTION
Single commit with tree=5389c60ff3c46eccadbc3f6fe9a6abeaed9dbf84^{tree}, parent=88f6798f4d6c95733b6c5c173615314f88d16719. Exact snapshot of upstream PR head. No conflict resolution attempted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated telemetry example: renamed data_streams_count to data_stream_count and indices_count to index_count for consistency in sample output.

- Tests
  - Adjusted test data generation to use a positive range for dataStreamCount in a specific branch.

- Chores
  - Removed a muted test entry related to TimeSeriesFeatureSetUsageTests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->