### PR TITLE
Mirror upstream elastic/elasticsearch#133945 for AI review (snapshot of HEAD tree)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
@@ -90,7 +90,8 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
         int numCentroids,
         IndexInput centroids,
         float[] target,
-        IndexInput postingListSlice
+        IndexInput postingListSlice,
+        float visitRatio
     ) throws IOException;
 
     private static IndexInput openDataInput(
@@ -252,7 +253,8 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
             entry.numCentroids,
             entry.centroidSlice(ivfCentroids),
             target,
-            postListSlice
+            postListSlice,
+            visitRatio
         );
         PostingVisitor scorer = getPostingVisitor(fieldInfo, postListSlice, target, acceptDocs);
         long expectedDocs = 0;


### PR DESCRIPTION
We have currently a fixed oversampling of 20% of the total centroid. This works well for low / medium number of centroids but starts being quite slow when the number of centroids increases. Now that we introduced a visit ratio we can make it dependent on that an oversample the number of centroids we expect to visit by a constant.

Local experiment shows no lost of recall and a nice speed up when the number of centroids is high.