### PR TITLE
Mirror upstream elastic/elasticsearch#133903 for AI review (snapshot of HEAD tree)

### DIFF
--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContext.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContext.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.routing.TsidBuilder;
 import org.elasticsearch.common.hash.BufferedMurmur3Hasher;
 import org.elasticsearch.common.hash.MurmurHash3.Hash128;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
 import org.elasticsearch.xpack.oteldata.otlp.tsid.DataPointTsidFunnel;
 import org.elasticsearch.xpack.oteldata.otlp.tsid.ResourceTsidFunnel;
@@ -160,17 +161,36 @@ public class DataPointGroupingContext {
     }
 
     class ScopeGroup {
+        private static final String RECEIVER = "/receiver/";
+
         private final ResourceGroup resourceGroup;
         private final InstrumentationScope scope;
         private final ByteString scopeSchemaUrl;
+        @Nullable
+        private final String receiverName;
         // index -> timestamp -> dataPointGroupHash -> DataPointGroup
-        private final Map<String, Map<Hash128, Map<Hash128, DataPointGroup>>> dataPointGroupsByIndexAndTimestamp;
+        private final Map<TargetIndex, Map<Hash128, Map<Hash128, DataPointGroup>>> dataPointGroupsByIndexAndTimestamp;
 
         ScopeGroup(ResourceGroup resourceGroup, InstrumentationScope scope, ByteString scopeSchemaUrl) {
             this.resourceGroup = resourceGroup;
             this.scope = scope;
             this.scopeSchemaUrl = scopeSchemaUrl;
             this.dataPointGroupsByIndexAndTimestamp = new HashMap<>();
+            this.receiverName = extractReceiverName(scope);
+        }
+
+        private @Nullable String extractReceiverName(InstrumentationScope scope) {
+            String scopeName = scope.getName();
+            int indexOfReceiver = scopeName.indexOf(RECEIVER);
+            if (indexOfReceiver >= 0) {
+                int beginIndex = indexOfReceiver + RECEIVER.length();
+                int endIndex = scopeName.indexOf('/', beginIndex);
+                if (endIndex < 0) {
+                    endIndex = scopeName.length();
+                }
+                return scopeName.substring(beginIndex, endIndex);
+            }
+            return null;
         }
 
         public <T> void addDataPoints(Metric metric, List<T> dataPoints, BiFunction<T, Metric, DataPoint> createDataPoint) {
@@ -197,8 +217,13 @@ public class DataPointGroupingContext {
             Hash128 dataPointGroupHash = dataPointGroupTsidBuilder.hash();
             // in addition to the fields that go into the _tsid, we also need to group by timestamp and start timestamp
             Hash128 timestamp = new Hash128(dataPoint.getTimestampUnixNano(), dataPoint.getStartTimestampUnixNano());
-            // TODO determine based on attributes and scope name
-            String targetIndex = "metrics-generic.otel-default";
+            TargetIndex targetIndex = TargetIndex.evaluate(
+                TargetIndex.TYPE_METRICS,
+                dataPoint.getAttributes(),
+                receiverName,
+                scope.getAttributesList(),
+                resourceGroup.resource.getAttributesList()
+            );
             var dataPointGroupsByTimestamp = dataPointGroupsByIndexAndTimestamp.computeIfAbsent(targetIndex, k -> new HashMap<>());
             var dataPointGroups = dataPointGroupsByTimestamp.computeIfAbsent(timestamp, k -> new HashMap<>());
             DataPointGroup dataPointGroup = dataPointGroups.get(dataPointGroupHash);
@@ -237,7 +262,7 @@ public class DataPointGroupingContext {
         private final String unit;
         private final Set<String> metricNames = new HashSet<>();
         private final List<DataPoint> dataPoints = new ArrayList<>();
-        private final String targetIndex;
+        private final TargetIndex targetIndex;
         private String metricNamesHash;
 
         public DataPointGroup(
@@ -247,7 +272,7 @@ public class DataPointGroupingContext {
             ByteString scopeSchemaUrl,
             List<KeyValue> dataPointAttributes,
             String unit,
-            String targetIndex
+            TargetIndex targetIndex
         ) {
             this.resource = resource;
             this.resourceSchemaUrl = resourceSchemaUrl;
@@ -318,7 +343,7 @@ public class DataPointGroupingContext {
             return dataPoints;
         }
 
-        public String targetIndex() {
+        public TargetIndex targetIndex() {
             return targetIndex;
         }
     }

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/TargetIndex.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/TargetIndex.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp.datapoint;
+
+import io.opentelemetry.proto.common.v1.KeyValue;
+
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.core.Nullable;
+
+import java.util.List;
+
+/**
+ * Represents the target index for a data point, which can be either a specific index or a data stream.
+ * The index is determined based on attributes, scope name, and default values.
+ */
+public final class TargetIndex {
+
+    public static final String TYPE_METRICS = "metrics";
+
+    private static final String ELASTICSEARCH_INDEX = "elasticsearch.index";
+    private static final String DATA_STREAM_DATASET = "data_stream.dataset";
+    private static final String DATA_STREAM_NAMESPACE = "data_stream.namespace";
+    private static final String DEFAULT_DATASET = "generic";
+    private static final String OTEL_DATASET_SUFFIX = ".otel";
+    private static final String DEFAULT_NAMESPACE = "default";
+    private static final TargetIndex DEFAULT_METRICS_TARGET = evaluate(TYPE_METRICS, List.of(), null, List.of(), List.of());
+
+    private String index;
+    private String type;
+    private String dataset;
+    private String namespace;
+
+    public static TargetIndex defaultMetrics() {
+        return DEFAULT_METRICS_TARGET;
+    }
+
+    public static boolean isTargetIndexAttribute(String attributeKey) {
+        return attributeKey.equals(ELASTICSEARCH_INDEX)
+            || attributeKey.equals(DATA_STREAM_DATASET)
+            || attributeKey.equals(DATA_STREAM_NAMESPACE);
+    }
+
+    /**
+     * Determines the target index for a data point.
+     *
+     * @param type The data stream type (e.g., "metrics", "logs").
+     * @param attributes The attributes associated with the data point.
+     * @param receiverName The name of the receiver, which may influence the dataset (receiver-based routing).
+     * @param scopeAttributes Attributes associated with the scope.
+     * @param resourceAttributes Attributes associated with the resource.
+     * @return A TargetIndex instance representing the target index for the data point.
+     */
+    public static TargetIndex evaluate(
+        String type,
+        List<KeyValue> attributes,
+        @Nullable String receiverName,
+        List<KeyValue> scopeAttributes,
+        List<KeyValue> resourceAttributes
+    ) {
+        // Order:
+        // 1. elasticsearch.index from attributes, scope.attributes, resource.attributes
+        // 2. read data_stream.* from attributes, scope.attributes, resource.attributes
+        // 3. receiver-based routing based on scope.name
+        // 4. use default hardcoded data_stream.* (<type>-generic-default)
+        TargetIndex target = new TargetIndex();
+        target.populateFrom(attributes);
+        target.populateFrom(scopeAttributes);
+        target.populateFrom(resourceAttributes);
+        if (target.index == null) {
+            target.type = type;
+            if (target.dataset == null && receiverName != null) {
+                target.dataset = receiverName;
+            }
+            target.dataset = DataStream.sanitizeDataset(target.dataset);
+            if (target.dataset == null) {
+                target.dataset = DEFAULT_DATASET;
+            }
+            // add otel suffix to match OTel index template
+            target.dataset = target.dataset + OTEL_DATASET_SUFFIX;
+            target.namespace = DataStream.sanitizeNamespace(target.namespace);
+
+            if (target.namespace == null) {
+                target.namespace = DEFAULT_NAMESPACE;
+            }
+            target.index = target.type + "-" + target.dataset + "-" + target.namespace;
+        } else {
+            target.type = null;
+            target.dataset = null;
+            target.namespace = null;
+        }
+        return target;
+    }
+
+    private TargetIndex() {}
+
+    private void populateFrom(List<KeyValue> attributes) {
+        if (isPopulated()) {
+            return;
+        }
+        for (int i = 0, size = attributes.size(); i < size; i++) {
+            KeyValue attr = attributes.get(i);
+            if (attr.getKey().equals(ELASTICSEARCH_INDEX)) {
+                index = attr.getValue().getStringValue();
+            } else if (dataset == null && attr.getKey().equals(DATA_STREAM_DATASET)) {
+                dataset = attr.getValue().getStringValue();
+            } else if (namespace == null && attr.getKey().equals(DATA_STREAM_NAMESPACE)) {
+                namespace = attr.getValue().getStringValue();
+            }
+        }
+    }
+
+    private boolean isPopulated() {
+        return (dataset != null && namespace != null) || index != null;
+    }
+
+    public boolean isDataStream() {
+        return type != null && dataset != null && namespace != null;
+    }
+
+    public String index() {
+        return index;
+    }
+
+    public String type() {
+        return type;
+    }
+
+    public String dataset() {
+        return dataset;
+    }
+
+    public String namespace() {
+        return namespace;
+    }
+
+    @Override
+    public String toString() {
+        return index;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TargetIndex that = (TargetIndex) o;
+        return index.equals(that.index);
+    }
+
+    @Override
+    public int hashCode() {
+        return index.hashCode();
+    }
+}

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MappingHints.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MappingHints.java
@@ -27,8 +27,7 @@ import java.util.List;
  *                              In these cases, the behavior is undefined but does not lead to data loss.
  */
 public record MappingHints(boolean aggregateMetricDouble, boolean docCount) {
-    public static final String MAPPING_HINTS = "elasticsearch.mapping.hints";
-
+    private static final String MAPPING_HINTS = "elasticsearch.mapping.hints";
     private static final MappingHints EMPTY = new MappingHints(false, false);
     private static final String AGGREGATE_METRIC_DOUBLE = "aggregate_metric_double";
     private static final String DOC_COUNT = "_doc_count";
@@ -61,5 +60,9 @@ public record MappingHints(boolean aggregateMetricDouble, boolean docCount) {
 
     public static MappingHints empty() {
         return EMPTY;
+    }
+
+    public static boolean isMappingHintsAttribute(String attributeKey) {
+        return attributeKey.equals(MAPPING_HINTS);
     }
 }

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.hash.BufferedMurmur3Hasher;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPoint;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPointGroupingContext;
+import org.elasticsearch.xpack.oteldata.otlp.datapoint.TargetIndex;
 import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
 
 import java.io.IOException;
@@ -49,6 +50,7 @@ public class MetricDocumentBuilder {
             builder.field("start_timestamp", TimeUnit.NANOSECONDS.toMillis(dataPointGroup.getStartTimestampUnixNano()));
         }
         buildResource(dataPointGroup.resource(), dataPointGroup.resourceSchemaUrl(), builder);
+        buildDataStream(builder, dataPointGroup.targetIndex());
         buildScope(builder, dataPointGroup.scopeSchemaUrl(), dataPointGroup.scope());
         buildDataPointAttributes(builder, dataPointGroup.dataPointAttributes(), dataPointGroup.unit());
         builder.field("_metric_names_hash", dataPointGroup.getMetricNamesHash(hasher));
@@ -110,6 +112,17 @@ public class MetricDocumentBuilder {
         }
     }
 
+    private void buildDataStream(XContentBuilder builder, TargetIndex targetIndex) throws IOException {
+        if (targetIndex.isDataStream() == false) {
+            return;
+        }
+        builder.startObject("data_stream");
+        builder.field("type", targetIndex.type());
+        builder.field("dataset", targetIndex.dataset());
+        builder.field("namespace", targetIndex.namespace());
+        builder.endObject();
+    }
+
     private void buildAttributes(XContentBuilder builder, List<KeyValue> attributes) throws IOException {
         for (int i = 0, size = attributes.size(); i < size; i++) {
             KeyValue attribute = attributes.get(i);
@@ -130,7 +143,7 @@ public class MetricDocumentBuilder {
      * @return true if the attribute is ignored, false otherwise
      */
     public static boolean isIgnoredAttribute(String attributeKey) {
-        return attributeKey.equals(MappingHints.MAPPING_HINTS);
+        return TargetIndex.isTargetIndexAttribute(attributeKey) || MappingHints.isMappingHintsAttribute(attributeKey);
     }
 
     private void attributeValue(XContentBuilder builder, AnyValue value) throws IOException {

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContextTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContextTests.java
@@ -13,6 +13,7 @@ import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -25,6 +26,7 @@ import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createResourceMetr
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createScopeMetrics;
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createSumMetric;
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.keyValue;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 
 public class DataPointGroupingContextTests extends ESTestCase {
@@ -55,6 +57,33 @@ public class DataPointGroupingContextTests extends ESTestCase {
         AtomicInteger groupCount = new AtomicInteger(0);
         context.consume(dataPointGroup -> groupCount.incrementAndGet());
         assertEquals(1, groupCount.get());
+    }
+
+    public void testGroupingDifferentTargetIndex() throws Exception {
+        // Group data points
+        ExportMetricsServiceRequest metricsRequest = createMetricsRequest(
+            List.of(
+                createGaugeMetric(
+                    "system.cpu.usage",
+                    "",
+                    List.of(createDoubleDataPoint(nowUnixNanos, nowUnixNanos, List.of(keyValue("data_stream.dataset", "custom"))))
+                ),
+                createGaugeMetric("system.memory.usage", "", List.of(createDoubleDataPoint(nowUnixNanos)))
+            )
+        );
+        context.groupDataPoints(metricsRequest);
+        assertEquals(2, context.totalDataPoints());
+        assertEquals(0, context.getIgnoredDataPoints());
+        assertEquals("", context.getIgnoredDataPointsMessage());
+
+        AtomicInteger groupCount = new AtomicInteger(0);
+        List<String> targetIndexes = new ArrayList<>();
+        context.consume(dataPointGroup -> {
+            groupCount.incrementAndGet();
+            targetIndexes.add(dataPointGroup.targetIndex().index());
+        });
+        assertEquals(2, groupCount.get());
+        assertThat(targetIndexes, containsInAnyOrder("metrics-custom.otel-default", "metrics-generic.otel-default"));
     }
 
     public void testGroupingDifferentGroupUnit() throws Exception {
@@ -210,6 +239,53 @@ public class DataPointGroupingContextTests extends ESTestCase {
         AtomicInteger groupCount = new AtomicInteger(0);
         context.consume(dataPointGroup -> groupCount.incrementAndGet());
         assertEquals(2, groupCount.get());
+    }
+
+    public void testReceiverBasedRouting() throws Exception {
+        String scopeName =
+            "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper";
+        ResourceMetrics resource = createResourceMetrics(
+            List.of(keyValue("service.name", "test-service_1")),
+            List.of(
+                createScopeMetrics(
+                    scopeName,
+                    "1.0.0",
+                    List.of(createGaugeMetric("system.cpu.usage", "", List.of(createDoubleDataPoint(nowUnixNanos))))
+                )
+            )
+        );
+
+        context.groupDataPoints(ExportMetricsServiceRequest.newBuilder().addAllResourceMetrics(List.of(resource)).build());
+        assertEquals(1, context.totalDataPoints());
+        assertEquals(0, context.getIgnoredDataPoints());
+        assertEquals("", context.getIgnoredDataPointsMessage());
+
+        List<String> targetIndexes = new ArrayList<>();
+        context.consume(dataPointGroup -> targetIndexes.add(dataPointGroup.targetIndex().index()));
+        assertThat(targetIndexes, containsInAnyOrder("metrics-hostmetricsreceiver.otel-default"));
+    }
+
+    public void testReceiverBasedRoutingWithoutTrailingSlash() throws Exception {
+        String scopeName = "/receiver/foo";
+        ResourceMetrics resource = createResourceMetrics(
+            List.of(keyValue("service.name", "test-service_1")),
+            List.of(
+                createScopeMetrics(
+                    scopeName,
+                    "1.0.0",
+                    List.of(createGaugeMetric("system.cpu.usage", "", List.of(createDoubleDataPoint(nowUnixNanos))))
+                )
+            )
+        );
+
+        context.groupDataPoints(ExportMetricsServiceRequest.newBuilder().addAllResourceMetrics(List.of(resource)).build());
+        assertEquals(1, context.totalDataPoints());
+        assertEquals(0, context.getIgnoredDataPoints());
+        assertEquals("", context.getIgnoredDataPointsMessage());
+
+        List<String> targetIndexes = new ArrayList<>();
+        context.consume(dataPointGroup -> targetIndexes.add(dataPointGroup.targetIndex().index()));
+        assertThat(targetIndexes, containsInAnyOrder("metrics-foo.otel-default"));
     }
 
 }

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/TargetIndexTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/TargetIndexTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp.datapoint;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class TargetIndexTests extends ESTestCase {
+
+    public void testEvaluateWithExplicitIndex() {
+        List<KeyValue> attributes = List.of(
+            createStringAttribute("elasticsearch.index", "custom-index"),
+            createStringAttribute("data_stream.dataset", "should-be-ignored"),
+            createStringAttribute("data_stream.namespace", "should-be-ignored")
+        );
+
+        TargetIndex index = TargetIndex.evaluate("metrics", attributes, null, List.of(), List.of());
+
+        assertThat(index.index(), equalTo("custom-index"));
+        assertThat(index.isDataStream(), is(false));
+        assertThat(index.type(), nullValue());
+        assertThat(index.dataset(), nullValue());
+        assertThat(index.namespace(), nullValue());
+    }
+
+    public void testEvaluateWithDataStreamAttributes() {
+        List<KeyValue> attributes = List.of(
+            createStringAttribute("data_stream.dataset", "custom-dataset"),
+            createStringAttribute("data_stream.namespace", "custom-namespace")
+        );
+
+        TargetIndex index = TargetIndex.evaluate("metrics", attributes, null, List.of(), List.of());
+
+        // DataStream.sanitizeDataset replaces hyphens with underscores
+        assertThat(index.index(), equalTo("metrics-custom_dataset.otel-custom-namespace"));
+        assertThat(index.isDataStream(), is(true));
+        assertThat(index.type(), equalTo("metrics"));
+        assertThat(index.dataset(), equalTo("custom_dataset.otel"));
+        assertThat(index.namespace(), equalTo("custom-namespace"));
+    }
+
+    public void testEvaluateWithScopeAttributes() {
+        List<KeyValue> scopeAttributes = List.of(
+            createStringAttribute("data_stream.dataset", "scope-dataset"),
+            createStringAttribute("data_stream.namespace", "scope-namespace")
+        );
+
+        TargetIndex index = TargetIndex.evaluate("metrics", List.of(), null, scopeAttributes, List.of());
+
+        // DataStream.sanitizeDataset replaces hyphens with underscores
+        assertThat(index.index(), equalTo("metrics-scope_dataset.otel-scope-namespace"));
+        assertThat(index.isDataStream(), is(true));
+        assertThat(index.type(), equalTo("metrics"));
+        assertThat(index.dataset(), equalTo("scope_dataset.otel"));
+        assertThat(index.namespace(), equalTo("scope-namespace"));
+    }
+
+    public void testEvaluateWithResourceAttributes() {
+        List<KeyValue> resourceAttributes = List.of(
+            createStringAttribute("data_stream.dataset", "resource-dataset"),
+            createStringAttribute("data_stream.namespace", "resource-namespace")
+        );
+
+        TargetIndex index = TargetIndex.evaluate("metrics", List.of(), null, List.of(), resourceAttributes);
+
+        // DataStream.sanitizeDataset replaces hyphens with underscores
+        assertThat(index.index(), equalTo("metrics-resource_dataset.otel-resource-namespace"));
+        assertThat(index.isDataStream(), is(true));
+        assertThat(index.type(), equalTo("metrics"));
+        assertThat(index.dataset(), equalTo("resource_dataset.otel"));
+        assertThat(index.namespace(), equalTo("resource-namespace"));
+    }
+
+    public void testAttributePrecedence() {
+        // The order of precedence should be: attributes > scopeAttributes > resourceAttributes
+        List<KeyValue> attributes = List.of(createStringAttribute("data_stream.dataset", "attr-dataset"));
+
+        List<KeyValue> scopeAttributes = List.of(
+            createStringAttribute("data_stream.dataset", "scope-dataset"),
+            createStringAttribute("data_stream.namespace", "scope-namespace")
+        );
+
+        List<KeyValue> resourceAttributes = List.of(
+            createStringAttribute("data_stream.dataset", "resource-dataset"),
+            createStringAttribute("data_stream.namespace", "resource-namespace")
+        );
+
+        TargetIndex index = TargetIndex.evaluate("metrics", attributes, null, scopeAttributes, resourceAttributes);
+
+        // DataStream.sanitizeDataset replaces hyphens with underscores
+        assertThat(index.index(), equalTo("metrics-attr_dataset.otel-scope-namespace"));
+        assertThat(index.isDataStream(), is(true));
+        assertThat(index.type(), equalTo("metrics"));
+        assertThat(index.dataset(), equalTo("attr_dataset.otel"));
+        assertThat(index.namespace(), equalTo("scope-namespace"));
+    }
+
+    public void testEvaluateWithReceiverInScopeName() {
+        TargetIndex index = TargetIndex.evaluate("metrics", List.of(), "hostmetrics-receiver", List.of(), List.of());
+
+        assertThat(index.index(), equalTo("metrics-hostmetrics_receiver.otel-default"));
+        assertThat(index.isDataStream(), is(true));
+        assertThat(index.type(), equalTo("metrics"));
+        assertThat(index.dataset(), equalTo("hostmetrics_receiver.otel"));
+        assertThat(index.namespace(), equalTo("default"));
+    }
+
+    public void testEvaluateWithDefaultValues() {
+        TargetIndex index = TargetIndex.evaluate("metrics", List.of(), null, List.of(), List.of());
+
+        assertThat(index.index(), equalTo("metrics-generic.otel-default"));
+        assertThat(index.isDataStream(), is(true));
+        assertThat(index.type(), equalTo("metrics"));
+        assertThat(index.dataset(), equalTo("generic.otel"));
+        assertThat(index.namespace(), equalTo("default"));
+    }
+
+    public void testDataStreamSanitization() {
+        List<KeyValue> attributes = List.of(
+            createStringAttribute("data_stream.dataset", "Some-Dataset"),
+            createStringAttribute("data_stream.namespace", "Some*Namespace")
+        );
+
+        TargetIndex index = TargetIndex.evaluate("metrics", attributes, null, List.of(), List.of());
+
+        // DataStream.sanitizeDataset and DataStream.sanitizeNamespace should be applied
+        assertThat(index.dataset(), equalTo("some_dataset.otel"));
+        assertThat(index.namespace(), equalTo("some_namespace"));
+    }
+
+    private KeyValue createStringAttribute(String key, String value) {
+        return KeyValue.newBuilder().setKey(key).setValue(AnyValue.newBuilder().setStringValue(value).build()).build();
+    }
+}

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilderTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilderTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPoint;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPointGroupingContext;
+import org.elasticsearch.xpack.oteldata.otlp.datapoint.TargetIndex;
 import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
 
 import java.io.IOException;
@@ -73,7 +74,7 @@ public class MetricDocumentBuilderTests extends ESTestCase {
             scopeSchemaUrl,
             dataPointAttributes,
             "{test}",
-            "metrics-generic.otel-default"
+            TargetIndex.defaultMetrics()
         );
         dataPointGroup.addDataPoint(
             Set.of(),
@@ -102,6 +103,9 @@ public class MetricDocumentBuilderTests extends ESTestCase {
 
         assertThat(doc.evaluate("@timestamp"), equalTo(TimeUnit.NANOSECONDS.toMillis(timestamp)));
         assertThat(doc.evaluate("start_timestamp"), equalTo(TimeUnit.NANOSECONDS.toMillis(startTimestamp)));
+        assertThat(doc.evaluate("data_stream.type"), equalTo("metrics"));
+        assertThat(doc.evaluate("data_stream.dataset"), equalTo("generic.otel"));
+        assertThat(doc.evaluate("data_stream.namespace"), equalTo("default"));
         assertThat(doc.evaluate("resource.schema_url"), equalTo("https://opentelemetry.io/schemas/1.0.0"));
         assertThat(doc.evaluate("resource.dropped_attributes_count"), equalTo(1));
         assertThat(doc.evaluate("resource.attributes.service\\.name"), equalTo("test-service"));
@@ -139,7 +143,7 @@ public class MetricDocumentBuilderTests extends ESTestCase {
             null,
             List.of(),
             "",
-            "metrics-generic.otel-default"
+            TargetIndex.defaultMetrics()
         );
         dataPointGroup.addDataPoint(
             Set.of(),
@@ -171,7 +175,7 @@ public class MetricDocumentBuilderTests extends ESTestCase {
             null,
             List.of(),
             "",
-            "metrics-generic.otel-default"
+            TargetIndex.defaultMetrics()
         );
 
         dataPointGroup.addDataPoint(

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/tsid/AttributeListTsidFunnelTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/tsid/AttributeListTsidFunnelTests.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.keyValue;
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.keyValueList;
+import static org.hamcrest.Matchers.equalTo;
 
 public class AttributeListTsidFunnelTests extends ESTestCase {
 
@@ -54,6 +55,18 @@ public class AttributeListTsidFunnelTests extends ESTestCase {
         plainBuilder.addLongDimension("attributes.nested.int", 42);
         plainBuilder.addStringDimension("attributes.foo", "bar");
         assertEquals(plainBuilder.hash(), funnelBuilder.hash());
+    }
+
+    public void testIgnoredAttributes() {
+        funnel.add(
+            List.of(
+                keyValue("elasticsearch.index", "index"),
+                keyValue("data_stream.dataset", "dataset"),
+                keyValue("data_stream.namespace", "namespace")
+            ),
+            funnelBuilder
+        );
+        assertThat(funnelBuilder.size(), equalTo(0));
     }
 
 }


### PR DESCRIPTION
Properly determines the target index for metric data points based on the following attributes:

* `data_stream.dataset`
* `data_stream.namespace`
* `elasticsearch.index`

This mimics the "dynamic routing" behavior of the [OTel collector's `elasticsearchexporter`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.132.0/exporter/elasticsearchexporter#elasticsearch-document-routing)

Part of https://github.com/elastic/elasticsearch/pull/133057