### PR TITLE
Mirror upstream elastic/elasticsearch#134413 for AI review (snapshot of HEAD tree)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tsdb-mapping.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tsdb-mapping.json
@@ -10,6 +10,10 @@
     "name": {
       "type": "keyword"
     },
+    "host": {
+      "type": "keyword",
+      "time_series_dimension": true
+    },
     "network": {
       "properties": {
         "connections": {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
@@ -10,7 +10,6 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
 import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
 import org.elasticsearch.xpack.esql.common.Failures;
@@ -29,7 +28,6 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.FilteredExpression;
-import org.elasticsearch.xpack.esql.expression.function.aggregate.Rate;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.TimeSeriesAggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.fulltext.FullTextFunction;
 import org.elasticsearch.xpack.esql.expression.function.grouping.Categorize;
@@ -243,16 +241,16 @@ public class Aggregate extends UnaryPlan
             // traverse the tree to find invalid matches
             checkInvalidNamedExpressionUsage(exp, groupings, groupRefs, failures, 0);
         });
-        if (anyMatch(l -> l instanceof EsRelation relation && relation.indexMode() == IndexMode.TIME_SERIES)) {
-            aggregates.forEach(a -> checkRateAggregates(a, 0, failures));
-        } else {
-            forEachExpression(
-                TimeSeriesAggregateFunction.class,
-                r -> failures.add(fail(r, "time_series aggregate[{}] can only be used with the TS command", r.sourceText()))
-            );
-        }
+        checkTimeSeriesAggregates(failures);
         checkCategorizeGrouping(failures);
         checkMultipleScoreAggregations(failures);
+    }
+
+    protected void checkTimeSeriesAggregates(Failures failures) {
+        forEachExpression(
+            TimeSeriesAggregateFunction.class,
+            r -> failures.add(fail(r, "time_series aggregate[{}] can only be used with the TS command", r.sourceText()))
+        );
     }
 
     private void checkMultipleScoreAggregations(Failures failures) {
@@ -351,22 +349,6 @@ public class Aggregate extends UnaryPlan
                 );
             }
         })));
-    }
-
-    private static void checkRateAggregates(Expression expr, int nestedLevel, Failures failures) {
-        if (expr instanceof AggregateFunction) {
-            nestedLevel++;
-        }
-        if (expr instanceof Rate r) {
-            if (nestedLevel != 2) {
-                failures.add(
-                    fail(expr, "the rate aggregate [{}] can only be used with the TS command and inside another aggregate", r.sourceText())
-                );
-            }
-        }
-        for (Expression child : expr.children()) {
-            checkRateAggregates(child, nestedLevel, failures);
-        }
     }
 
     // traverse the expression and look either for an agg function or a grouping match


### PR DESCRIPTION
Add validations to reject the following queries until supported:

1. Limit and sort cannot be used to alter the time-series source:
   - `TS metrics | LIMIT ... | STATS ...`
   - `TS metrics | SORT BY ... | STATS ...`

2. Over-time aggregation without an outer aggregation (to be supported soon):
   - `TS metrics | STATS rate(requests)`
   - `TS metrics | STATS last_over_time(requests)`

3. Reject lookup join, enrich, change point before the first stats.

Closes #134366
Closes #134372