### PR TITLE
Mirror upstream elastic/elasticsearch#134851 for AI review (snapshot of HEAD tree)

### DIFF
--- a/docs/changelog/134851.yaml
+++ b/docs/changelog/134851.yaml
@@ -1,0 +1,5 @@
+pr: 134851
+summary: Remove ingest conditionals `_type` deprecation warning
+area: Ingest Node
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
@@ -9,9 +9,6 @@
 
 package org.elasticsearch.ingest;
 
-import org.elasticsearch.common.logging.DeprecationCategory;
-import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.script.DynamicMap;
 import org.elasticsearch.script.IngestConditionalScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptException;
@@ -28,7 +25,6 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
@@ -38,16 +34,6 @@ import static org.elasticsearch.ingest.ConfigurationUtils.newConfigurationExcept
  * A wrapping processor that adds 'if' logic around the wrapped processor.
  */
 public class ConditionalProcessor extends AbstractProcessor implements WrappingProcessor {
-
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(DynamicMap.class);
-    private static final Map<String, Function<Object, Object>> FUNCTIONS = Map.of("_type", value -> {
-        deprecationLogger.warn(
-            DeprecationCategory.INDICES,
-            "conditional-processor__type",
-            "[types removal] Looking up doc types [_type] in scripts is deprecated."
-        );
-        return value;
-    });
 
     static final String TYPE = "conditional";
 
@@ -144,10 +130,7 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
         if (factory == null) {
             factory = scriptService.compile(condition, IngestConditionalScript.CONTEXT);
         }
-        return factory.newInstance(
-            condition.getParams(),
-            new UnmodifiableIngestData(new DynamicMap(ingestDocument.getSourceAndMetadata(), FUNCTIONS))
-        ).execute();
+        return factory.newInstance(condition.getParams(), new UnmodifiableIngestData(ingestDocument.getSourceAndMetadata())).execute();
     }
 
     public Processor getInnerProcessor() {


### PR DESCRIPTION
`_type` isn't special in ingest conditional scripts anymore, and we shouldn't warn about it as if it is.

With this pipeline:
```
PUT _ingest/pipeline/underscore_type
{
  "processors": [
    {
      "script": {
        "source": "ctx._foo = ctx._bar"  # this is a field
      }
    },
    {
      "script": {
        "source": "ctx._baz = ctx._type" # no warning from this, it's not a _conditional_
      }
    },
    {
      "set": {
        "if": "ctx._type == null", # this warns on `main` but won't anymore after this PR
        "field": "message_1",
        "value": "test"
      }
    },
    {
      "set": {
        "if": "ctx._missing == null", # this is just another field
        "field": "message_2",
        "value": "some other test"
      }
    }
  ]
}
```

This` _simulate` call:
```
POST _ingest/pipeline/underscore_type/_simulate
{
  "docs": [
    {
      "_index": "index",
      "_id": "id",
      "_source": {
        "hello": "world",
        "_bar": "quux"
      }
    }
  ]
}
```
gives this result on `main`: 
```
// Warning: 299 Elasticsearch-9.2.0-494dc7075a299cb5edb06c36681601550c4fcdae "[types removal] Looking up doc types [_type] in scripts is deprecated."
{
  "docs" : [
    {
      "doc" : {
        "_index" : "index",
        "_version" : "-3",
        "_id" : "id",
        "_source" : {
          "_baz" : null,
          "message_2" : "some other test",
          "message_1" : "test",
          "_bar" : "quux",
          "hello" : "world",
          "_foo" : "quux"
        },
        "_ingest" : {
          "timestamp" : "2025-09-16T21:36:01.143913Z"
        }
      }
    }
  ]
}
```

The result would be the same after this PR, there just wouldn't be a warning anymore -- that is, `_type` is just a regular old non-special field, like `_foo` or `_bar` or whatever (edit: that is, at least in terms of **reads**).

Related to https://github.com/elastic/elasticsearch/pull/134816, in that I'm pulling a part of that out as its own PR for searchability and accounting purposes.