### PR TITLE
Mirror upstream elastic/elasticsearch#134980 for AI review (snapshot of HEAD tree)

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -233,7 +233,7 @@ Note, however, that wildcard field patterns will only resolve to fields that eit
 
 ### Limitations
 
-- **Single index**: Multi-field queries currently work with single index searches only
+- **Single index**: Until 9.2, multi-field queries only work with single index searches.
 - **CCS (Cross Cluster Search)**: Multi-field queries do not support remote cluster searches
 
 ### Examples

--- a/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
+++ b/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
@@ -445,13 +445,13 @@ public class RRFRetrieverBuilderTests extends AbstractRetrieverBuilderTests<RRFR
             null
         );
 
-        // Non-default rank window size
+        // Non-default rank window size and non-default rank_constant
         retriever = new RRFRetrieverBuilder(
             null,
             List.of("field_1", "field_2", "semantic_field_1", "semantic_field_2"),
             "foo2",
             DEFAULT_RANK_WINDOW_SIZE * 2,
-            RRFRetrieverBuilder.DEFAULT_RANK_CONSTANT,
+            RRFRetrieverBuilder.DEFAULT_RANK_CONSTANT * 2,
             new float[0]
         );
         assertMultiIndexMultiFieldsParamsRewrite(


### PR DESCRIPTION
Also addressed a test change from https://github.com/elastic/elasticsearch/pull/134822#discussion_r2357946866

We removed the limitation for being to able a single index with the simplified RRF and linear retrievers in:

https://github.com/elastic/elasticsearch/pull/133720
https://github.com/elastic/elasticsearch/pull/134822

so we can remove this limitation from the documentation.