### PR TITLE
Mirror upstream elastic/elasticsearch#134985 for AI review (snapshot of HEAD tree)

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/AuthorizationStatePersistenceUtils.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/AuthorizationStatePersistenceUtils.java
@@ -130,7 +130,7 @@ public final class AuthorizationStatePersistenceUtils {
             },
             error -> {
                 String msg = TransformMessages.getMessage(TransformMessages.FAILED_TO_LOAD_TRANSFORM_STATE, transformId);
-                logger.error(msg, error);
+                logger.warn(msg, error);
                 listener.onFailure(error);
             }
         );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformIndex.java
@@ -213,7 +213,7 @@ public final class TransformIndex {
                     config.getDestination().getIndex(),
                     config.getId()
                 );
-                logger.error(message, e);
+                logger.warn(message, e);
                 listener.onFailure(new RuntimeException(message, e));
             })
         );
@@ -255,7 +255,7 @@ public final class TransformIndex {
                     config.getDestination().getIndex(),
                     config.getId()
                 );
-                logger.error(message, e);
+                logger.warn(message, e);
                 listener.onFailure(new RuntimeException(message, e));
             })
         );


### PR DESCRIPTION
This PR decreases loglevel of 3 transform-related error messages from ERROR -> WARN.
These 3 error messages (more precisely 2 of them) make up for ~88% (358/407) of all serverless errors in the last month making the `[Transforms] Serverless: Error in transform logs` alert too noisy to be useful.