### PR TITLE
Mirror upstream elastic/elasticsearch#134477 for AI review (snapshot of HEAD tree)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Setting;
@@ -588,6 +589,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
      * @param shardId        id of the shard being searched
      * @param taskId         id of the task being executed
      * @param threadPool     with context where to write the new header
+     * @param lifecycle      the lifecycle of the service that wraps the listener.
+     *                       If the service is stopped or closed it will always log as debug
      * @return the wrapped action listener
      */
     static <T> ActionListener<T> wrapListenerForErrorHandling(
@@ -596,7 +599,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         String nodeId,
         ShardId shardId,
         long taskId,
-        ThreadPool threadPool
+        ThreadPool threadPool,
+        Lifecycle lifecycle
     ) {
         final boolean header;
         if (version.onOrAfter(ERROR_TRACE_IN_TRANSPORT_HEADER) && threadPool.getThreadContext() != null) {
@@ -612,7 +616,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 taskId
             );
             // Keep this logic aligned with that of SUPPRESSED_ERROR_LOGGER in RestResponse
-            if (ExceptionsHelper.status(e).getStatus() < 500 || ExceptionsHelper.isNodeOrShardUnavailableTypeException(e)) {
+            if (ExceptionsHelper.status(e).getStatus() < 500
+                || ExceptionsHelper.isNodeOrShardUnavailableTypeException(e)
+                || lifecycle.stoppedOrClosed()) {
                 logger.debug(messageSupplier, e);
             } else {
                 logger.warn(messageSupplier, e);
@@ -643,7 +649,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             clusterService.localNode().getId(),
             request.shardId(),
             task.getId(),
-            threadPool
+            threadPool,
+            lifecycle
         );
         final IndexShard shard = getShard(request);
         rewriteAndFetchShardRequest(shard, request, listener.delegateFailure((l, rewritten) -> {
@@ -705,7 +712,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 clusterService.localNode().getId(),
                 request.shardId(),
                 task.getId(),
-                threadPool
+                threadPool,
+                lifecycle
             ).delegateFailure((l, orig) -> {
                 // check if we can shortcut the query phase entirely.
                 if (orig.canReturnNullResponseIfMatchNoDocs()) {
@@ -953,7 +961,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             clusterService.localNode().getId(),
             shardSearchRequest.shardId(),
             task.getId(),
-            threadPool
+            threadPool,
+            lifecycle
         );
         final Releasable markAsUsed = readerContext.markAsUsed(getKeepAlive(shardSearchRequest));
         runAsync(getExecutor(readerContext.indexShard()), () -> {
@@ -1010,7 +1019,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             clusterService.localNode().getId(),
             readerContext.indexShard().shardId(),
             task.getId(),
-            threadPool
+            threadPool,
+            lifecycle
         );
         final Releasable markAsUsed;
         try {
@@ -1072,7 +1082,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             clusterService.localNode().getId(),
             shardSearchRequest.shardId(),
             task.getId(),
-            threadPool
+            threadPool,
+            lifecycle
         );
         final Releasable markAsUsed = readerContext.markAsUsed(getKeepAlive(shardSearchRequest));
         rewriteAndFetchShardRequest(readerContext.indexShard(), shardSearchRequest, listener.delegateFailure((l, rewritten) -> {

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
@@ -160,9 +161,31 @@ public class SearchServiceTests extends IndexShardTestCase {
         e.fillInStackTrace();
         assertThat(e.getStackTrace().length, is(not(0)));
         listener.onFailure(e);
-        listener = wrapListenerForErrorHandling(listener, TransportVersion.current(), "node", shardId, 123L, threadPool);
+        listener = wrapListenerForErrorHandling(listener, TransportVersion.current(), "node", shardId, 123L, threadPool, randomLifecycle());
         isWrapped.set(true);
         listener.onFailure(e);
+    }
+
+    private static Lifecycle randomLifecycle() {
+        return randomBoolean() ? randomInitializedOrStartedLifecycle() : randomStoppedOrClosedLifecycle();
+    }
+
+    private static Lifecycle randomInitializedOrStartedLifecycle() {
+        Lifecycle lifecycle = new Lifecycle();
+        if (randomBoolean()) {
+            lifecycle.started();
+        }
+        return lifecycle;
+    }
+
+    private static Lifecycle randomStoppedOrClosedLifecycle() {
+        Lifecycle lifecycle = new Lifecycle();
+        lifecycle.started();
+        lifecycle.stopped();
+        if (randomBoolean()) {
+            lifecycle.closed();
+        }
+        return lifecycle;
     }
 
     public void testWrapListenerForErrorHandlingDebugLog() {
@@ -197,9 +220,31 @@ public class SearchServiceTests extends IndexShardTestCase {
                     mockLog.assertAllExpectationsMatched();
                 }
             };
-            IllegalArgumentException e = new IllegalArgumentException(exceptionMessage); // 400-level exception
-            listener = wrapListenerForErrorHandling(listener, TransportVersion.current(), nodeId, shardId, taskId, threadPool);
-            listener.onFailure(e);
+            // Default behavior is to use debug level for 400-level exceptions
+            IllegalArgumentException iae = new IllegalArgumentException(exceptionMessage); // 400-level exception
+            listener = wrapListenerForErrorHandling(
+                listener,
+                TransportVersion.current(),
+                nodeId,
+                shardId,
+                taskId,
+                threadPool,
+                randomLifecycle()
+            );
+            listener.onFailure(iae);
+
+            // Debug logging for a 500-level exception when closing or stopped lifecycle is to log as debug level
+            IllegalStateException ise = new IllegalStateException(exceptionMessage);
+            listener = wrapListenerForErrorHandling(
+                listener,
+                TransportVersion.current(),
+                nodeId,
+                shardId,
+                taskId,
+                threadPool,
+                randomStoppedOrClosedLifecycle()
+            );
+            listener.onFailure(ise);
         }
     }
 
@@ -235,7 +280,15 @@ public class SearchServiceTests extends IndexShardTestCase {
                 }
             };
             IllegalStateException e = new IllegalStateException(exceptionMessage); // 500-level exception
-            listener = wrapListenerForErrorHandling(listener, TransportVersion.current(), nodeId, shardId, taskId, threadPool);
+            listener = wrapListenerForErrorHandling(
+                listener,
+                TransportVersion.current(),
+                nodeId,
+                shardId,
+                taskId,
+                threadPool,
+                randomInitializedOrStartedLifecycle()
+            );
             listener.onFailure(e);
         }
     }


### PR DESCRIPTION
`SearchService` will log warnings for its listeners on a 500. However, this is expected when the SearchService is already closed or stopped, so a warning should not be logged for this.

WARN level logs are alerting on serverless because of this.

This PR changes the listener wrapping on the `SearchService` so it receives the lifecycle as well. When it's stopped or closed, errors will be logged as debug messages.