### PR TITLE
Mirror upstream elastic/elasticsearch#134452 for AI review (snapshot of HEAD tree)

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expression.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expression.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -101,7 +102,9 @@ public abstract class Expression extends Node<Expression> implements Resolvable 
 
     public abstract Nullability nullable();
 
-    // the references/inputs/leaves of the expression tree
+    /**
+     * {@link Set} of {@link Attribute}s referenced by this {@link Expression}.
+     */
     public AttributeSet references() {
         if (lazyReferences == null) {
             lazyReferences = Expressions.references(children());

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expressions.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expressions.java
@@ -101,6 +101,15 @@ public final class Expressions {
     }
 
     public static AttributeSet references(List<? extends Expression> exps) {
+        if (exps.size() == 1) {
+            /*
+             * If we're getting the references from a single expression it's safe
+             * to just use its references. This is quite common. We use a ton of
+             * Aliases, for example. And every unary function can share its references
+             * with its input.
+             */
+            return exps.getFirst().references();
+        }
         return AttributeSet.of(exps, Expression::references);
     }
 


### PR DESCRIPTION
Makes calls to `Expression#references()` reuse the reference set returned by it's child when there is only one child. This should save on many `AttributeSet`s, especially in degenerate plans that have a zillion `EVAL`s. Things like `Alias` will always be able to reuse the child references. So will unary functions. And probably other things.

This does require that folks treat the `references()` as immutable. I thikn they technically are mutable, but no one I *saw* mutates them because that's... going to break things anyway.