### PR TITLE
Mirror upstream elastic/elasticsearch#133845 for AI review (snapshot of HEAD tree)

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -358,6 +358,7 @@ public class TransportVersions {
     public static final TransportVersion RESOLVE_INDEX_MODE_FILTER = def(9_149_0_00);
     public static final TransportVersion SEMANTIC_QUERY_MULTIPLE_INFERENCE_IDS = def(9_150_0_00);
     public static final TransportVersion ESQL_LOOKUP_JOIN_PRE_JOIN_FILTER = def(9_151_0_00);
+    public static final TransportVersion INFERENCE_API_DISABLE_EIS_RATE_LIMITING = def(9_152_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorService.java
@@ -449,9 +449,11 @@ public class RequestExecutorService implements RequestExecutor {
         }
 
         private TimeValue executeEnqueuedTaskInternal() {
-            var timeBeforeAvailableToken = rateLimiter.timeToReserve(1);
-            if (shouldExecuteImmediately(timeBeforeAvailableToken) == false) {
-                return timeBeforeAvailableToken;
+            if (rateLimitSettings.isEnabled()) {
+                var timeBeforeAvailableToken = rateLimiter.timeToReserve(1);
+                if (shouldExecuteImmediately(timeBeforeAvailableToken) == false) {
+                    return timeBeforeAvailableToken;
+                }
             }
 
             var task = queue.poll();
@@ -463,9 +465,11 @@ public class RequestExecutorService implements RequestExecutor {
                 return NO_TASKS_AVAILABLE;
             }
 
-            // We should never have to wait because we checked above
-            var reserveRes = rateLimiter.reserve(1);
-            assert shouldExecuteImmediately(reserveRes) : "Reserving request tokens required a sleep when it should not have";
+            if (rateLimitSettings.isEnabled()) {
+                // We should never have to wait because we checked above
+                var reserveRes = rateLimiter.reserve(1);
+                assert shouldExecuteImmediately(reserveRes) : "Reserving request tokens required a sleep when it should not have";
+            }
 
             task.getRequestManager()
                 .execute(task.getInferenceInputs(), requestSender, task.getRequestCompletedFunction(), task.getListener());

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -193,7 +193,7 @@ public class ElasticInferenceService extends SenderService {
                     DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1,
                     TaskType.CHAT_COMPLETION,
                     NAME,
-                    new ElasticInferenceServiceCompletionServiceSettings(DEFAULT_CHAT_COMPLETION_MODEL_ID_V1, null),
+                    new ElasticInferenceServiceCompletionServiceSettings(DEFAULT_CHAT_COMPLETION_MODEL_ID_V1),
                     EmptyTaskSettings.INSTANCE,
                     EmptySecretSettings.INSTANCE,
                     elasticInferenceServiceComponents
@@ -206,7 +206,7 @@ public class ElasticInferenceService extends SenderService {
                     DEFAULT_ELSER_ENDPOINT_ID_V2,
                     TaskType.SPARSE_EMBEDDING,
                     NAME,
-                    new ElasticInferenceServiceSparseEmbeddingsServiceSettings(DEFAULT_ELSER_2_MODEL_ID, null, null),
+                    new ElasticInferenceServiceSparseEmbeddingsServiceSettings(DEFAULT_ELSER_2_MODEL_ID, null),
                     EmptyTaskSettings.INSTANCE,
                     EmptySecretSettings.INSTANCE,
                     elasticInferenceServiceComponents,
@@ -224,8 +224,7 @@ public class ElasticInferenceService extends SenderService {
                         DEFAULT_MULTILINGUAL_EMBED_MODEL_ID,
                         defaultDenseTextEmbeddingsSimilarity(),
                         null,
-                        null,
-                        ElasticInferenceServiceDenseTextEmbeddingsServiceSettings.DEFAULT_RATE_LIMIT_SETTINGS
+                        null
                     ),
                     EmptyTaskSettings.INSTANCE,
                     EmptySecretSettings.INSTANCE,
@@ -245,7 +244,7 @@ public class ElasticInferenceService extends SenderService {
                     DEFAULT_RERANK_ENDPOINT_ID_V1,
                     TaskType.RERANK,
                     NAME,
-                    new ElasticInferenceServiceRerankServiceSettings(DEFAULT_RERANK_MODEL_ID_V1, null),
+                    new ElasticInferenceServiceRerankServiceSettings(DEFAULT_RERANK_MODEL_ID_V1),
                     EmptyTaskSettings.INSTANCE,
                     EmptySecretSettings.INSTANCE,
                     elasticInferenceServiceComponents
@@ -622,8 +621,7 @@ public class ElasticInferenceService extends SenderService {
                 modelId,
                 similarityToUse,
                 embeddingSize,
-                maxInputTokens,
-                serviceSettings.rateLimitSettings()
+                maxInputTokens
             );
 
             return new ElasticInferenceServiceDenseTextEmbeddingsModel(embeddingsModel, updateServiceSettings);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionModel.java
@@ -35,8 +35,7 @@ public class ElasticInferenceServiceCompletionModel extends ElasticInferenceServ
     ) {
         var originalModelServiceSettings = model.getServiceSettings();
         var overriddenServiceSettings = new ElasticInferenceServiceCompletionServiceSettings(
-            Objects.requireNonNullElse(request.model(), originalModelServiceSettings.modelId()),
-            originalModelServiceSettings.rateLimitSettings()
+            Objects.requireNonNullElse(request.model(), originalModelServiceSettings.modelId())
         );
 
         return new ElasticInferenceServiceCompletionModel(model, overriddenServiceSettings);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionServiceSettings.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
+import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService;
@@ -35,38 +36,41 @@ public class ElasticInferenceServiceCompletionServiceSettings extends FilteredXC
 
     public static final String NAME = "elastic_inference_service_completion_service_settings";
 
-    private static final RateLimitSettings DEFAULT_RATE_LIMIT_SETTINGS = new RateLimitSettings(720L);
-
     public static ElasticInferenceServiceCompletionServiceSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
         ValidationException validationException = new ValidationException();
 
         String modelId = extractRequiredString(map, MODEL_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
-        RateLimitSettings rateLimitSettings = RateLimitSettings.of(
+
+        RateLimitSettings.rejectRateLimitFieldForRequestContext(
             map,
-            DEFAULT_RATE_LIMIT_SETTINGS,
-            validationException,
+            ModelConfigurations.SERVICE_SETTINGS,
             ElasticInferenceService.NAME,
-            context
+            TaskType.CHAT_COMPLETION,
+            context,
+            validationException
         );
 
         if (validationException.validationErrors().isEmpty() == false) {
             throw validationException;
         }
 
-        return new ElasticInferenceServiceCompletionServiceSettings(modelId, rateLimitSettings);
+        return new ElasticInferenceServiceCompletionServiceSettings(modelId);
     }
 
     private final String modelId;
     private final RateLimitSettings rateLimitSettings;
 
-    public ElasticInferenceServiceCompletionServiceSettings(String modelId, RateLimitSettings rateLimitSettings) {
+    public ElasticInferenceServiceCompletionServiceSettings(String modelId) {
         this.modelId = Objects.requireNonNull(modelId);
-        this.rateLimitSettings = Objects.requireNonNullElse(rateLimitSettings, DEFAULT_RATE_LIMIT_SETTINGS);
+        this.rateLimitSettings = RateLimitSettings.DISABLED_INSTANCE;
     }
 
     public ElasticInferenceServiceCompletionServiceSettings(StreamInput in) throws IOException {
         this.modelId = in.readString();
-        this.rateLimitSettings = new RateLimitSettings(in);
+        this.rateLimitSettings = RateLimitSettings.DISABLED_INSTANCE;
+        if (in.getTransportVersion().before(TransportVersions.INFERENCE_API_DISABLE_EIS_RATE_LIMITING)) {
+            new RateLimitSettings(in);
+        }
     }
 
     @Override
@@ -110,7 +114,9 @@ public class ElasticInferenceServiceCompletionServiceSettings extends FilteredXC
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(modelId);
-        rateLimitSettings.writeTo(out);
+        if (out.getTransportVersion().before(TransportVersions.INFERENCE_API_DISABLE_EIS_RATE_LIMITING)) {
+            rateLimitSettings.writeTo(out);
+        }
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/densetextembeddings/ElasticInferenceServiceDenseTextEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/densetextembeddings/ElasticInferenceServiceDenseTextEmbeddingsServiceSettings.java
@@ -17,6 +17,7 @@ import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.inference.SimilarityMeasure;
+import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService;
@@ -43,8 +44,6 @@ public class ElasticInferenceServiceDenseTextEmbeddingsServiceSettings extends F
 
     public static final String NAME = "elastic_inference_service_dense_embeddings_service_settings";
 
-    public static final RateLimitSettings DEFAULT_RATE_LIMIT_SETTINGS = new RateLimitSettings(10_000);
-
     private final String modelId;
     private final SimilarityMeasure similarity;
     private final Integer dimensions;
@@ -55,76 +54,40 @@ public class ElasticInferenceServiceDenseTextEmbeddingsServiceSettings extends F
         Map<String, Object> map,
         ConfigurationParseContext context
     ) {
-        return switch (context) {
-            case REQUEST -> fromRequestMap(map, context);
-            case PERSISTENT -> fromPersistentMap(map, context);
-        };
-    }
-
-    private static ElasticInferenceServiceDenseTextEmbeddingsServiceSettings fromRequestMap(
-        Map<String, Object> map,
-        ConfigurationParseContext context
-    ) {
         ValidationException validationException = new ValidationException();
 
         String modelId = extractRequiredString(map, MODEL_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
-        RateLimitSettings rateLimitSettings = RateLimitSettings.of(
-            map,
-            DEFAULT_RATE_LIMIT_SETTINGS,
-            validationException,
-            ElasticInferenceService.NAME,
-            context
-        );
-
         SimilarityMeasure similarity = extractSimilarity(map, ModelConfigurations.SERVICE_SETTINGS, validationException);
         Integer dims = removeAsType(map, DIMENSIONS, Integer.class);
         Integer maxInputTokens = removeAsType(map, MAX_INPUT_TOKENS, Integer.class);
+
+        RateLimitSettings.rejectRateLimitFieldForRequestContext(
+            map,
+            ModelConfigurations.SERVICE_SETTINGS,
+            ElasticInferenceService.NAME,
+            TaskType.TEXT_EMBEDDING,
+            context,
+            validationException
+        );
 
         if (validationException.validationErrors().isEmpty() == false) {
             throw validationException;
         }
 
-        return new ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(modelId, similarity, dims, maxInputTokens, rateLimitSettings);
-    }
-
-    private static ElasticInferenceServiceDenseTextEmbeddingsServiceSettings fromPersistentMap(
-        Map<String, Object> map,
-        ConfigurationParseContext context
-    ) {
-        ValidationException validationException = new ValidationException();
-
-        String modelId = extractRequiredString(map, MODEL_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
-        RateLimitSettings rateLimitSettings = RateLimitSettings.of(
-            map,
-            DEFAULT_RATE_LIMIT_SETTINGS,
-            validationException,
-            ElasticInferenceService.NAME,
-            context
-        );
-
-        SimilarityMeasure similarity = extractSimilarity(map, ModelConfigurations.SERVICE_SETTINGS, validationException);
-        Integer dims = removeAsType(map, DIMENSIONS, Integer.class);
-        Integer maxInputTokens = removeAsType(map, MAX_INPUT_TOKENS, Integer.class);
-
-        if (validationException.validationErrors().isEmpty() == false) {
-            throw validationException;
-        }
-
-        return new ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(modelId, similarity, dims, maxInputTokens, rateLimitSettings);
+        return new ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(modelId, similarity, dims, maxInputTokens);
     }
 
     public ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(
         String modelId,
         @Nullable SimilarityMeasure similarity,
         @Nullable Integer dimensions,
-        @Nullable Integer maxInputTokens,
-        RateLimitSettings rateLimitSettings
+        @Nullable Integer maxInputTokens
     ) {
         this.modelId = modelId;
         this.similarity = similarity;
         this.dimensions = dimensions;
         this.maxInputTokens = maxInputTokens;
-        this.rateLimitSettings = Objects.requireNonNullElse(rateLimitSettings, DEFAULT_RATE_LIMIT_SETTINGS);
+        this.rateLimitSettings = RateLimitSettings.DISABLED_INSTANCE;
     }
 
     public ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(StreamInput in) throws IOException {
@@ -132,7 +95,11 @@ public class ElasticInferenceServiceDenseTextEmbeddingsServiceSettings extends F
         this.similarity = in.readOptionalEnum(SimilarityMeasure.class);
         this.dimensions = in.readOptionalVInt();
         this.maxInputTokens = in.readOptionalVInt();
-        this.rateLimitSettings = new RateLimitSettings(in);
+        this.rateLimitSettings = RateLimitSettings.DISABLED_INSTANCE;
+
+        if (in.getTransportVersion().before(TransportVersions.INFERENCE_API_DISABLE_EIS_RATE_LIMITING)) {
+            new RateLimitSettings(in);
+        }
     }
 
     @Override
@@ -221,7 +188,9 @@ public class ElasticInferenceServiceDenseTextEmbeddingsServiceSettings extends F
         out.writeOptionalEnum(SimilarityMeasure.translateSimilarity(similarity, out.getTransportVersion()));
         out.writeOptionalVInt(dimensions);
         out.writeOptionalVInt(maxInputTokens);
-        rateLimitSettings.writeTo(out);
+        if (out.getTransportVersion().before(TransportVersions.INFERENCE_API_DISABLE_EIS_RATE_LIMITING)) {
+            rateLimitSettings.writeTo(out);
+        }
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/rerank/ElasticInferenceServiceRerankServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/rerank/ElasticInferenceServiceRerankServiceSettings.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
+import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService;
@@ -35,35 +36,42 @@ public class ElasticInferenceServiceRerankServiceSettings extends FilteredXConte
 
     public static final String NAME = "elastic_rerank_service_settings";
 
-    private static final RateLimitSettings DEFAULT_RATE_LIMIT_SETTINGS = new RateLimitSettings(500);
-
     public static ElasticInferenceServiceRerankServiceSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
         ValidationException validationException = new ValidationException();
 
         String modelId = extractRequiredString(map, MODEL_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
-        RateLimitSettings rateLimitSettings = RateLimitSettings.of(
+
+        RateLimitSettings.rejectRateLimitFieldForRequestContext(
             map,
-            DEFAULT_RATE_LIMIT_SETTINGS,
-            validationException,
+            ModelConfigurations.SERVICE_SETTINGS,
             ElasticInferenceService.NAME,
-            context
+            TaskType.RERANK,
+            context,
+            validationException
         );
 
-        return new ElasticInferenceServiceRerankServiceSettings(modelId, rateLimitSettings);
+        if (validationException.validationErrors().isEmpty() == false) {
+            throw validationException;
+        }
+
+        return new ElasticInferenceServiceRerankServiceSettings(modelId);
     }
 
     private final String modelId;
 
     private final RateLimitSettings rateLimitSettings;
 
-    public ElasticInferenceServiceRerankServiceSettings(String modelId, RateLimitSettings rateLimitSettings) {
+    public ElasticInferenceServiceRerankServiceSettings(String modelId) {
         this.modelId = Objects.requireNonNull(modelId);
-        this.rateLimitSettings = Objects.requireNonNullElse(rateLimitSettings, DEFAULT_RATE_LIMIT_SETTINGS);
+        this.rateLimitSettings = RateLimitSettings.DISABLED_INSTANCE;
     }
 
     public ElasticInferenceServiceRerankServiceSettings(StreamInput in) throws IOException {
         this.modelId = in.readString();
-        this.rateLimitSettings = new RateLimitSettings(in);
+        this.rateLimitSettings = RateLimitSettings.DISABLED_INSTANCE;
+        if (in.getTransportVersion().before(TransportVersions.INFERENCE_API_DISABLE_EIS_RATE_LIMITING)) {
+            new RateLimitSettings(in);
+        }
     }
 
     @Override
@@ -115,7 +123,9 @@ public class ElasticInferenceServiceRerankServiceSettings extends FilteredXConte
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(modelId);
-        rateLimitSettings.writeTo(out);
+        if (out.getTransportVersion().before(TransportVersions.INFERENCE_API_DISABLE_EIS_RATE_LIMITING)) {
+            rateLimitSettings.writeTo(out);
+        }
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/sparseembeddings/ElasticInferenceServiceSparseEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/sparseembeddings/ElasticInferenceServiceSparseEmbeddingsServiceSettings.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
+import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService;
@@ -38,8 +39,6 @@ public class ElasticInferenceServiceSparseEmbeddingsServiceSettings extends Filt
 
     public static final String NAME = "elastic_inference_service_sparse_embeddings_service_settings";
 
-    private static final RateLimitSettings DEFAULT_RATE_LIMIT_SETTINGS = new RateLimitSettings(1_000);
-
     public static ElasticInferenceServiceSparseEmbeddingsServiceSettings fromMap(
         Map<String, Object> map,
         ConfigurationParseContext context
@@ -54,19 +53,20 @@ public class ElasticInferenceServiceSparseEmbeddingsServiceSettings extends Filt
             validationException
         );
 
-        RateLimitSettings rateLimitSettings = RateLimitSettings.of(
+        RateLimitSettings.rejectRateLimitFieldForRequestContext(
             map,
-            DEFAULT_RATE_LIMIT_SETTINGS,
-            validationException,
+            ModelConfigurations.SERVICE_SETTINGS,
             ElasticInferenceService.NAME,
-            context
+            TaskType.SPARSE_EMBEDDING,
+            context,
+            validationException
         );
 
         if (validationException.validationErrors().isEmpty() == false) {
             throw validationException;
         }
 
-        return new ElasticInferenceServiceSparseEmbeddingsServiceSettings(modelId, maxInputTokens, rateLimitSettings);
+        return new ElasticInferenceServiceSparseEmbeddingsServiceSettings(modelId, maxInputTokens);
     }
 
     private final String modelId;
@@ -74,20 +74,19 @@ public class ElasticInferenceServiceSparseEmbeddingsServiceSettings extends Filt
     private final Integer maxInputTokens;
     private final RateLimitSettings rateLimitSettings;
 
-    public ElasticInferenceServiceSparseEmbeddingsServiceSettings(
-        String modelId,
-        @Nullable Integer maxInputTokens,
-        @Nullable RateLimitSettings rateLimitSettings
-    ) {
+    public ElasticInferenceServiceSparseEmbeddingsServiceSettings(String modelId, @Nullable Integer maxInputTokens) {
         this.modelId = Objects.requireNonNull(modelId);
         this.maxInputTokens = maxInputTokens;
-        this.rateLimitSettings = Objects.requireNonNullElse(rateLimitSettings, DEFAULT_RATE_LIMIT_SETTINGS);
+        this.rateLimitSettings = RateLimitSettings.DISABLED_INSTANCE;
     }
 
     public ElasticInferenceServiceSparseEmbeddingsServiceSettings(StreamInput in) throws IOException {
         this.modelId = in.readString();
         this.maxInputTokens = in.readOptionalVInt();
-        this.rateLimitSettings = new RateLimitSettings(in);
+        this.rateLimitSettings = RateLimitSettings.DISABLED_INSTANCE;
+        if (in.getTransportVersion().before(TransportVersions.INFERENCE_API_DISABLE_EIS_RATE_LIMITING)) {
+            new RateLimitSettings(in);
+        }
     }
 
     @Override
@@ -139,7 +138,9 @@ public class ElasticInferenceServiceSparseEmbeddingsServiceSettings extends Filt
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(modelId);
         out.writeOptionalVInt(maxInputTokens);
-        rateLimitSettings.writeTo(out);
+        if (out.getTransportVersion().before(TransportVersions.INFERENCE_API_DISABLE_EIS_RATE_LIMITING)) {
+            rateLimitSettings.writeTo(out);
+        }
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/settings/RateLimitSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/settings/RateLimitSettings.java
@@ -7,10 +7,12 @@
 
 package org.elasticsearch.xpack.inference.services.settings;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Strings;
 import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
@@ -32,9 +34,7 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwIfNot
 public class RateLimitSettings implements Writeable, ToXContentFragment {
     public static final String FIELD_NAME = "rate_limit";
     public static final String REQUESTS_PER_MINUTE_FIELD = "requests_per_minute";
-
-    private final long requestsPerTimeUnit;
-    private final TimeUnit timeUnit;
+    public static final RateLimitSettings DISABLED_INSTANCE = new RateLimitSettings(1, TimeUnit.MINUTES, false);
 
     public static RateLimitSettings of(
         Map<String, Object> map,
@@ -51,6 +51,26 @@ public class RateLimitSettings implements Writeable, ToXContentFragment {
         }
 
         return requestsPerMinute == null ? defaultValue : new RateLimitSettings(requestsPerMinute);
+    }
+
+    public static void rejectRateLimitFieldForRequestContext(
+        Map<String, Object> map,
+        String scope,
+        String service,
+        TaskType taskType,
+        ConfigurationParseContext context,
+        ValidationException validationException
+    ) {
+        if (ConfigurationParseContext.isRequestContext(context) && map.containsKey(FIELD_NAME)) {
+            validationException.addValidationError(
+                Strings.format(
+                    "[%s] rate limit settings are not permitted for service [%s] and task type [%s]",
+                    scope,
+                    service,
+                    taskType.toString()
+                )
+            );
+        }
     }
 
     public static Map<String, SettingsConfiguration> toSettingsConfigurationWithDescription(
@@ -75,6 +95,10 @@ public class RateLimitSettings implements Writeable, ToXContentFragment {
         return RateLimitSettings.toSettingsConfigurationWithDescription("Minimize the number of rate limit errors.", supportedTaskTypes);
     }
 
+    private final long requestsPerTimeUnit;
+    private final TimeUnit timeUnit;
+    private final boolean enabled;
+
     /**
      * Defines the settings in requests per minute
      * @param requestsPerMinute _
@@ -84,6 +108,8 @@ public class RateLimitSettings implements Writeable, ToXContentFragment {
     }
 
     /**
+     * This should only be used for testing.
+     *
      * Defines the settings in requests per the time unit provided
      * @param requestsPerTimeUnit number of requests
      * @param timeUnit _
@@ -91,16 +117,27 @@ public class RateLimitSettings implements Writeable, ToXContentFragment {
      * Note: The time unit is not serialized
      */
     public RateLimitSettings(long requestsPerTimeUnit, TimeUnit timeUnit) {
+        this(requestsPerTimeUnit, timeUnit, true);
+    }
+
+    // This should only be used for testing.
+    RateLimitSettings(long requestsPerTimeUnit, TimeUnit timeUnit, boolean enabled) {
         if (requestsPerTimeUnit <= 0) {
             throw new IllegalArgumentException("requests per minute must be positive");
         }
         this.requestsPerTimeUnit = requestsPerTimeUnit;
         this.timeUnit = Objects.requireNonNull(timeUnit);
+        this.enabled = enabled;
     }
 
     public RateLimitSettings(StreamInput in) throws IOException {
         requestsPerTimeUnit = in.readVLong();
         timeUnit = TimeUnit.MINUTES;
+        if (in.getTransportVersion().onOrAfter(TransportVersions.INFERENCE_API_DISABLE_EIS_RATE_LIMITING)) {
+            enabled = in.readBoolean();
+        } else {
+            enabled = true;
+        }
     }
 
     public long requestsPerTimeUnit() {
@@ -111,8 +148,16 @@ public class RateLimitSettings implements Writeable, ToXContentFragment {
         return timeUnit;
     }
 
+    public boolean isEnabled() {
+        return enabled;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        if (enabled == false) {
+            return builder;
+        }
+
         builder.startObject(FIELD_NAME);
         builder.field(REQUESTS_PER_MINUTE_FIELD, requestsPerTimeUnit);
         builder.endObject();
@@ -122,6 +167,9 @@ public class RateLimitSettings implements Writeable, ToXContentFragment {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(requestsPerTimeUnit);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.INFERENCE_API_DISABLE_EIS_RATE_LIMITING)) {
+            out.writeBoolean(enabled);
+        }
     }
 
     @Override
@@ -129,11 +177,13 @@ public class RateLimitSettings implements Writeable, ToXContentFragment {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         RateLimitSettings that = (RateLimitSettings) o;
-        return Objects.equals(requestsPerTimeUnit, that.requestsPerTimeUnit) && Objects.equals(timeUnit, that.timeUnit);
+        return Objects.equals(requestsPerTimeUnit, that.requestsPerTimeUnit)
+            && Objects.equals(timeUnit, that.timeUnit)
+            && enabled == that.enabled;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(requestsPerTimeUnit, timeUnit);
+        return Objects.hash(requestsPerTimeUnit, timeUnit, enabled);
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorServiceTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.inference.InputTypeTests;
 import org.elasticsearch.xpack.inference.common.RateLimiter;
 import org.elasticsearch.xpack.inference.external.http.retry.RequestSender;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryingHttpSender;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
@@ -52,6 +53,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -567,6 +569,46 @@ public class RequestExecutorServiceTests extends ESTestCase {
         service.start();
 
         verifyNoInteractions(requestSender);
+    }
+
+    public void testDoesNotAttemptToReserveTokens_WhenRateLimitSettingsDisabled() throws ExecutionException, InterruptedException,
+        TimeoutException {
+        var mockRateLimiter = mock(RateLimiter.class);
+        RequestExecutorService.RateLimiterCreator rateLimiterCreator = (a, b, c) -> mockRateLimiter;
+
+        var requestSender = mock(RetryingHttpSender.class);
+        var settings = createRequestExecutorServiceSettings(1);
+        var service = new RequestExecutorService(
+            threadPool,
+            RequestExecutorService.DEFAULT_QUEUE_CREATOR,
+            null,
+            settings,
+            requestSender,
+            Clock.systemUTC(),
+            rateLimiterCreator
+        );
+        var requestManager = RequestManagerTests.createMock(requestSender, "id", RateLimitSettings.DISABLED_INSTANCE);
+
+        PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
+        service.execute(requestManager, new EmbeddingsInput(List.of(), null), null, listener);
+
+        var waitToShutdown = new CountDownLatch(1);
+        var waitToReturnFromSend = new CountDownLatch(1);
+        // There is a request already queued, and its execution path will initiate shutting down the service
+        doAnswer(invocation -> {
+            waitToShutdown.countDown();
+            waitToReturnFromSend.await(TIMEOUT.getSeconds(), TimeUnit.SECONDS);
+            return Void.TYPE;
+        }).when(requestSender).send(any(), any(), any(), any(), any());
+
+        Future<?> executorTermination = submitShutdownRequest(waitToShutdown, waitToReturnFromSend, service);
+
+        service.start();
+        executorTermination.get(TIMEOUT.millis(), TimeUnit.MILLISECONDS);
+
+        // The request manager that we create has RateLimitSettings.DISABLED_INSTANCE, so we should never call the rate limiter
+        verify(mockRateLimiter, never()).timeToReserve(anyInt());
+        verify(mockRateLimiter, never()).reserve(anyInt());
     }
 
     public void testDoesNotExecuteTask_WhenCannotReserveTokens_AndThenCanReserve_AndExecutesTask() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModelTests.java
@@ -26,7 +26,7 @@ public class ElasticInferenceServiceSparseEmbeddingsModelTests extends ESTestCas
             "id",
             TaskType.SPARSE_EMBEDDING,
             "service",
-            new ElasticInferenceServiceSparseEmbeddingsServiceSettings(modelId, maxInputTokens, null),
+            new ElasticInferenceServiceSparseEmbeddingsServiceSettings(modelId, maxInputTokens),
             EmptyTaskSettings.INSTANCE,
             EmptySecretSettings.INSTANCE,
             ElasticInferenceServiceComponents.of(url),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsServiceSettingsTests.java
@@ -7,25 +7,31 @@
 
 package org.elasticsearch.xpack.inference.services.elastic;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 import org.elasticsearch.xpack.inference.services.elastic.sparseembeddings.ElasticInferenceServiceSparseEmbeddingsServiceSettings;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElserModelsTests.randomElserModel;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 
-public class ElasticInferenceServiceSparseEmbeddingsServiceSettingsTests extends AbstractWireSerializingTestCase<
+public class ElasticInferenceServiceSparseEmbeddingsServiceSettingsTests extends AbstractBWCWireSerializationTestCase<
     ElasticInferenceServiceSparseEmbeddingsServiceSettings> {
 
     @Override
@@ -53,23 +59,82 @@ public class ElasticInferenceServiceSparseEmbeddingsServiceSettingsTests extends
             ConfigurationParseContext.REQUEST
         );
 
-        assertThat(serviceSettings, is(new ElasticInferenceServiceSparseEmbeddingsServiceSettings(modelId, null, null)));
+        assertThat(serviceSettings, is(new ElasticInferenceServiceSparseEmbeddingsServiceSettings(modelId, null)));
+    }
+
+    public void testFromMap_DoesNotRemoveRateLimitField_DoesNotThrowValidationException_PersistentContext() {
+        var modelId = "my-model-id";
+        var map = new HashMap<String, Object>(
+            Map.of(
+                ServiceFields.MODEL_ID,
+                modelId,
+                RateLimitSettings.FIELD_NAME,
+                new HashMap<>(Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))
+            )
+        );
+        var serviceSettings = ElasticInferenceServiceSparseEmbeddingsServiceSettings.fromMap(map, ConfigurationParseContext.PERSISTENT);
+
+        assertThat(map, is(Map.of(RateLimitSettings.FIELD_NAME, Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))));
+        assertThat(serviceSettings, is(new ElasticInferenceServiceSparseEmbeddingsServiceSettings(modelId, null)));
+        assertThat(serviceSettings.rateLimitSettings(), sameInstance(RateLimitSettings.DISABLED_INSTANCE));
+    }
+
+    public void testFromMap_DoesNotRemoveRateLimitField_DoesNotThrowValidationException_WhenRateLimitFieldDoesNotExist() {
+        var modelId = "my-model-id";
+        var map = new HashMap<String, Object>(Map.of(ServiceFields.MODEL_ID, modelId));
+        var serviceSettings = ElasticInferenceServiceSparseEmbeddingsServiceSettings.fromMap(map, ConfigurationParseContext.PERSISTENT);
+
+        assertThat(map, anEmptyMap());
+        assertThat(serviceSettings, is(new ElasticInferenceServiceSparseEmbeddingsServiceSettings(modelId, null)));
+        assertThat(serviceSettings.rateLimitSettings(), sameInstance(RateLimitSettings.DISABLED_INSTANCE));
+    }
+
+    public void testFromMap_DoesThrowValidationException_WhenRateLimitFieldDoesExist_RequestContext() {
+        var modelId = "my-model-id";
+        var map = new HashMap<String, Object>(
+            Map.of(
+                ServiceFields.MODEL_ID,
+                modelId,
+                RateLimitSettings.FIELD_NAME,
+                new HashMap<>(Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))
+            )
+        );
+        var exception = expectThrows(
+            ValidationException.class,
+            () -> ElasticInferenceServiceSparseEmbeddingsServiceSettings.fromMap(map, ConfigurationParseContext.REQUEST)
+        );
+
+        assertThat(
+            exception.getMessage(),
+            containsString(
+                "[service_settings] rate limit settings are not permitted for service [elastic] and task type [sparse_embedding]"
+            )
+        );
+        assertThat(map, is(Map.of(RateLimitSettings.FIELD_NAME, Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))));
     }
 
     public void testToXContent_WritesAllFields() throws IOException {
         var modelId = ElserModels.ELSER_V1_MODEL;
         var maxInputTokens = 10;
-        var serviceSettings = new ElasticInferenceServiceSparseEmbeddingsServiceSettings(modelId, maxInputTokens, null);
+        var serviceSettings = new ElasticInferenceServiceSparseEmbeddingsServiceSettings(modelId, maxInputTokens);
 
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
         serviceSettings.toXContent(builder, null);
         String xContentResult = Strings.toString(builder);
 
         assertThat(xContentResult, is(Strings.format("""
-            {"model_id":"%s","max_input_tokens":%d,"rate_limit":{"requests_per_minute":1000}}""", modelId, maxInputTokens)));
+            {"model_id":"%s","max_input_tokens":%d}""", modelId, maxInputTokens)));
     }
 
     public static ElasticInferenceServiceSparseEmbeddingsServiceSettings createRandom() {
-        return new ElasticInferenceServiceSparseEmbeddingsServiceSettings(randomElserModel(), randomNonNegativeInt(), null);
+        return new ElasticInferenceServiceSparseEmbeddingsServiceSettings(randomElserModel(), randomNonNegativeInt());
+    }
+
+    @Override
+    protected ElasticInferenceServiceSparseEmbeddingsServiceSettings mutateInstanceForVersion(
+        ElasticInferenceServiceSparseEmbeddingsServiceSettings instance,
+        TransportVersion version
+    ) {
+        return instance;
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationHandlerTests.java
@@ -257,7 +257,7 @@ public class ElasticInferenceServiceAuthorizationHandlerTests extends ESSingleNo
                     defaultEndpointId("rainbow-sprinkles"),
                     TaskType.CHAT_COMPLETION,
                     "test",
-                    new ElasticInferenceServiceCompletionServiceSettings("rainbow-sprinkles", null),
+                    new ElasticInferenceServiceCompletionServiceSettings("rainbow-sprinkles"),
                     EmptyTaskSettings.INSTANCE,
                     EmptySecretSettings.INSTANCE,
                     ElasticInferenceServiceComponents.EMPTY_INSTANCE
@@ -270,7 +270,7 @@ public class ElasticInferenceServiceAuthorizationHandlerTests extends ESSingleNo
                     defaultEndpointId("elser-2"),
                     TaskType.SPARSE_EMBEDDING,
                     "test",
-                    new ElasticInferenceServiceSparseEmbeddingsServiceSettings("elser-2", null, null),
+                    new ElasticInferenceServiceSparseEmbeddingsServiceSettings("elser-2", null),
                     EmptyTaskSettings.INSTANCE,
                     EmptySecretSettings.INSTANCE,
                     ElasticInferenceServiceComponents.EMPTY_INSTANCE,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionModelTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.UnifiedCompletionRequest;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceComponents;
-import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 import java.util.List;
 
@@ -26,7 +25,7 @@ public class ElasticInferenceServiceCompletionModelTests extends ESTestCase {
             "id",
             TaskType.COMPLETION,
             "elastic",
-            new ElasticInferenceServiceCompletionServiceSettings("model_id", new RateLimitSettings(100)),
+            new ElasticInferenceServiceCompletionServiceSettings("model_id"),
             EmptyTaskSettings.INSTANCE,
             EmptySecretSettings.INSTANCE,
             ElasticInferenceServiceComponents.of("url")

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionServiceSettingsTests.java
@@ -7,17 +7,18 @@
 
 package org.elasticsearch.xpack.inference.services.elastic.completion;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
-import org.elasticsearch.xpack.inference.services.settings.RateLimitSettingsTests;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -25,8 +26,9 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 
-public class ElasticInferenceServiceCompletionServiceSettingsTests extends AbstractWireSerializingTestCase<
+public class ElasticInferenceServiceCompletionServiceSettingsTests extends AbstractBWCWireSerializationTestCase<
     ElasticInferenceServiceCompletionServiceSettings> {
 
     @Override
@@ -53,7 +55,49 @@ public class ElasticInferenceServiceCompletionServiceSettingsTests extends Abstr
             ConfigurationParseContext.REQUEST
         );
 
-        assertThat(serviceSettings, is(new ElasticInferenceServiceCompletionServiceSettings(modelId, new RateLimitSettings(720L))));
+        assertThat(serviceSettings, is(new ElasticInferenceServiceCompletionServiceSettings(modelId)));
+        assertThat(serviceSettings.rateLimitSettings(), sameInstance(RateLimitSettings.DISABLED_INSTANCE));
+    }
+
+    public void testFromMap_ThrowsValidationError_IfRateLimitFieldExists_ForRequestContext() {
+        var modelId = "my-model-id";
+
+        var map = new HashMap<String, Object>(
+            Map.of(
+                ServiceFields.MODEL_ID,
+                modelId,
+                RateLimitSettings.FIELD_NAME,
+                new HashMap<>(Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))
+            )
+        );
+        var exception = expectThrows(
+            ValidationException.class,
+            () -> ElasticInferenceServiceCompletionServiceSettings.fromMap(map, ConfigurationParseContext.REQUEST)
+        );
+
+        assertThat(
+            exception.getMessage(),
+            containsString("[service_settings] rate limit settings are not permitted for service [elastic] and task type [chat_completion]")
+        );
+    }
+
+    public void testFromMap_DoesNotThrowValidationError_IfRateLimitFieldExists_ForPersistentContext() {
+        var modelId = "my-model-id";
+
+        var map = new HashMap<String, Object>(
+            Map.of(
+                ServiceFields.MODEL_ID,
+                modelId,
+                RateLimitSettings.FIELD_NAME,
+                new HashMap<>(Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))
+            )
+        );
+
+        var serviceSettings = ElasticInferenceServiceCompletionServiceSettings.fromMap(map, ConfigurationParseContext.PERSISTENT);
+
+        assertThat(map, is(Map.of(RateLimitSettings.FIELD_NAME, Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))));
+        assertThat(serviceSettings, is(new ElasticInferenceServiceCompletionServiceSettings(modelId)));
+        assertThat(serviceSettings.rateLimitSettings(), sameInstance(RateLimitSettings.DISABLED_INSTANCE));
     }
 
     public void testFromMap_MissingModelId_ThrowsException() {
@@ -67,17 +111,27 @@ public class ElasticInferenceServiceCompletionServiceSettingsTests extends Abstr
 
     public void testToXContent_WritesAllFields() throws IOException {
         var modelId = "model_id";
-        var serviceSettings = new ElasticInferenceServiceCompletionServiceSettings(modelId, new RateLimitSettings(1000));
+        var serviceSettings = new ElasticInferenceServiceCompletionServiceSettings(modelId);
 
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
         serviceSettings.toXContent(builder, null);
         String xContentResult = Strings.toString(builder);
 
-        assertThat(xContentResult, is(Strings.format("""
-            {"model_id":"%s","rate_limit":{"requests_per_minute":1000}}""", modelId)));
+        assertThat(xContentResult, is(XContentHelper.stripWhitespace(Strings.format("""
+            {
+                "model_id":"%s"
+            }""", modelId))));
     }
 
     public static ElasticInferenceServiceCompletionServiceSettings createRandom() {
-        return new ElasticInferenceServiceCompletionServiceSettings(randomAlphaOfLength(4), RateLimitSettingsTests.createRandom());
+        return new ElasticInferenceServiceCompletionServiceSettings(randomAlphaOfLength(4));
+    }
+
+    @Override
+    protected ElasticInferenceServiceCompletionServiceSettings mutateInstanceForVersion(
+        ElasticInferenceServiceCompletionServiceSettings instance,
+        TransportVersion version
+    ) {
+        return instance;
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/densetextembeddings/ElasticInferenceServiceDenseTextEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/densetextembeddings/ElasticInferenceServiceDenseTextEmbeddingsModelTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceComponents;
-import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 public class ElasticInferenceServiceDenseTextEmbeddingsModelTests {
 
@@ -22,13 +21,7 @@ public class ElasticInferenceServiceDenseTextEmbeddingsModelTests {
             "id",
             TaskType.TEXT_EMBEDDING,
             "elastic",
-            new ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(
-                modelId,
-                SimilarityMeasure.COSINE,
-                null,
-                null,
-                new RateLimitSettings(1000L)
-            ),
+            new ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(modelId, SimilarityMeasure.COSINE, null, null),
             EmptyTaskSettings.INSTANCE,
             EmptySecretSettings.INSTANCE,
             ElasticInferenceServiceComponents.of(url),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/densetextembeddings/ElasticInferenceServiceDenseTextEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/densetextembeddings/ElasticInferenceServiceDenseTextEmbeddingsServiceSettingsTests.java
@@ -7,13 +7,16 @@
 
 package org.elasticsearch.xpack.inference.services.elastic.densetextembeddings;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.inference.SimilarityMeasure;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
@@ -22,9 +25,12 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 
-public class ElasticInferenceServiceDenseTextEmbeddingsServiceSettingsTests extends AbstractWireSerializingTestCase<
+public class ElasticInferenceServiceDenseTextEmbeddingsServiceSettingsTests extends AbstractBWCWireSerializationTestCase<
     ElasticInferenceServiceDenseTextEmbeddingsServiceSettings> {
 
     @Override
@@ -72,48 +78,127 @@ public class ElasticInferenceServiceDenseTextEmbeddingsServiceSettingsTests exte
         assertThat(serviceSettings.maxInputTokens(), is(maxInputTokens));
     }
 
+    public void testFromMap_WithAllSettings_DoesNotRemoveRateLimitField_DoesNotThrowValidationException_PersistentContext() {
+        var modelId = "my-dense-model-id";
+        var similarity = SimilarityMeasure.COSINE;
+        var dimensions = 384;
+        var maxInputTokens = 512;
+
+        var map = new HashMap<String, Object>(
+            Map.of(
+                ServiceFields.MODEL_ID,
+                modelId,
+                ServiceFields.SIMILARITY,
+                similarity.toString(),
+                ServiceFields.DIMENSIONS,
+                dimensions,
+                ServiceFields.MAX_INPUT_TOKENS,
+                maxInputTokens,
+                RateLimitSettings.FIELD_NAME,
+                new HashMap<>(Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))
+            )
+        );
+        var serviceSettings = ElasticInferenceServiceDenseTextEmbeddingsServiceSettings.fromMap(map, ConfigurationParseContext.PERSISTENT);
+
+        assertThat(map, is(Map.of(RateLimitSettings.FIELD_NAME, Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))));
+        assertThat(serviceSettings.modelId(), is(modelId));
+        assertThat(serviceSettings.similarity(), is(similarity));
+        assertThat(serviceSettings.dimensions(), is(dimensions));
+        assertThat(serviceSettings.maxInputTokens(), is(maxInputTokens));
+        assertThat(serviceSettings.rateLimitSettings(), sameInstance(RateLimitSettings.DISABLED_INSTANCE));
+    }
+
+    public void testFromMap_WithAllSettings_DoesNotRemoveRateLimitField_ThrowsValidationException_RequestContext() {
+        var modelId = "my-dense-model-id";
+        var similarity = SimilarityMeasure.COSINE;
+        var dimensions = 384;
+        var maxInputTokens = 512;
+
+        var map = new HashMap<String, Object>(
+            Map.of(
+                ServiceFields.MODEL_ID,
+                modelId,
+                ServiceFields.SIMILARITY,
+                similarity.toString(),
+                ServiceFields.DIMENSIONS,
+                dimensions,
+                ServiceFields.MAX_INPUT_TOKENS,
+                maxInputTokens,
+                RateLimitSettings.FIELD_NAME,
+                new HashMap<>(Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))
+            )
+        );
+        var exception = expectThrows(
+            ValidationException.class,
+            () -> ElasticInferenceServiceDenseTextEmbeddingsServiceSettings.fromMap(map, ConfigurationParseContext.REQUEST)
+        );
+
+        assertThat(map, is(Map.of(RateLimitSettings.FIELD_NAME, Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))));
+        assertThat(
+            exception.getMessage(),
+            containsString("[service_settings] rate limit settings are not permitted for service [elastic] and task type [text_embedding]")
+        );
+    }
+
+    public void testFromMap_WithAllSettings_DoesNotThrowValidationException_WhenRateLimitFieldDoesNotExist_RequestContext() {
+        var modelId = "my-dense-model-id";
+        var similarity = SimilarityMeasure.COSINE;
+        var dimensions = 384;
+        var maxInputTokens = 512;
+
+        var map = new HashMap<String, Object>(
+            Map.of(
+                ServiceFields.MODEL_ID,
+                modelId,
+                ServiceFields.SIMILARITY,
+                similarity.toString(),
+                ServiceFields.DIMENSIONS,
+                dimensions,
+                ServiceFields.MAX_INPUT_TOKENS,
+                maxInputTokens
+            )
+        );
+        var serviceSettings = ElasticInferenceServiceDenseTextEmbeddingsServiceSettings.fromMap(map, ConfigurationParseContext.REQUEST);
+
+        assertThat(map, anEmptyMap());
+        assertThat(serviceSettings.modelId(), is(modelId));
+        assertThat(serviceSettings.similarity(), is(similarity));
+        assertThat(serviceSettings.dimensions(), is(dimensions));
+        assertThat(serviceSettings.maxInputTokens(), is(maxInputTokens));
+        assertThat(serviceSettings.rateLimitSettings(), sameInstance(RateLimitSettings.DISABLED_INSTANCE));
+    }
+
     public void testToXContent_WritesAllFields() throws IOException {
         var modelId = "my-dense-model";
         var similarity = SimilarityMeasure.DOT_PRODUCT;
         var dimensions = 1024;
         var maxInputTokens = 256;
-        var rateLimitSettings = new RateLimitSettings(5000);
 
         var serviceSettings = new ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(
             modelId,
             similarity,
             dimensions,
-            maxInputTokens,
-            rateLimitSettings
+            maxInputTokens
         );
 
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
         serviceSettings.toXContent(builder, null);
         String xContentResult = Strings.toString(builder);
 
-        String expectedResult = Strings.format(
-            """
-                {"similarity":"%s","dimensions":%d,"max_input_tokens":%d,"model_id":"%s","rate_limit":{"requests_per_minute":%d}}""",
-            similarity,
-            dimensions,
-            maxInputTokens,
-            modelId,
-            rateLimitSettings.requestsPerTimeUnit()
-        );
+        String expectedResult = Strings.format("""
+            {"similarity":"%s","dimensions":%d,"max_input_tokens":%d,"model_id":"%s"}""", similarity, dimensions, maxInputTokens, modelId);
 
         assertThat(xContentResult, is(expectedResult));
     }
 
     public void testToXContent_WritesOnlyNonNullFields() throws IOException {
         var modelId = "my-dense-model";
-        var rateLimitSettings = new RateLimitSettings(2000);
 
         var serviceSettings = new ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(
             modelId,
             null, // similarity
             null, // dimensions
-            null, // maxInputTokens
-            rateLimitSettings
+            null // maxInputTokens
         );
 
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
@@ -121,20 +206,13 @@ public class ElasticInferenceServiceDenseTextEmbeddingsServiceSettingsTests exte
         String xContentResult = Strings.toString(builder);
 
         assertThat(xContentResult, is(Strings.format("""
-            {"model_id":"%s","rate_limit":{"requests_per_minute":%d}}""", modelId, rateLimitSettings.requestsPerTimeUnit())));
+            {"model_id":"%s"}""", modelId)));
     }
 
     public void testToXContentFragmentOfExposedFields() throws IOException {
         var modelId = "my-dense-model";
-        var rateLimitSettings = new RateLimitSettings(1500);
 
-        var serviceSettings = new ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(
-            modelId,
-            SimilarityMeasure.COSINE,
-            512,
-            128,
-            rateLimitSettings
-        );
+        var serviceSettings = new ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(modelId, SimilarityMeasure.COSINE, 512, 128);
 
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
         builder.startObject();
@@ -143,8 +221,8 @@ public class ElasticInferenceServiceDenseTextEmbeddingsServiceSettingsTests exte
         String xContentResult = Strings.toString(builder);
 
         // Only model_id and rate_limit should be in exposed fields
-        assertThat(xContentResult, is(Strings.format("""
-            {"model_id":"%s","rate_limit":{"requests_per_minute":%d}}""", modelId, rateLimitSettings.requestsPerTimeUnit())));
+        assertThat(xContentResult, is(XContentHelper.stripWhitespace(Strings.format("""
+            {"model_id":"%s"}""", modelId))));
     }
 
     public static ElasticInferenceServiceDenseTextEmbeddingsServiceSettings createRandom() {
@@ -152,14 +230,15 @@ public class ElasticInferenceServiceDenseTextEmbeddingsServiceSettingsTests exte
         var similarity = SimilarityMeasure.COSINE;
         var dimensions = randomBoolean() ? randomIntBetween(1, 1024) : null;
         var maxInputTokens = randomBoolean() ? randomIntBetween(128, 256) : null;
-        var rateLimitSettings = randomBoolean() ? new RateLimitSettings(randomIntBetween(1, 10000)) : null;
 
-        return new ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(
-            modelId,
-            similarity,
-            dimensions,
-            maxInputTokens,
-            rateLimitSettings
-        );
+        return new ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(modelId, similarity, dimensions, maxInputTokens);
+    }
+
+    @Override
+    protected ElasticInferenceServiceDenseTextEmbeddingsServiceSettings mutateInstanceForVersion(
+        ElasticInferenceServiceDenseTextEmbeddingsServiceSettings instance,
+        TransportVersion version
+    ) {
+        return instance;
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/rerank/ElasticInferenceServiceRerankModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/rerank/ElasticInferenceServiceRerankModelTests.java
@@ -20,7 +20,7 @@ public class ElasticInferenceServiceRerankModelTests extends ESTestCase {
             "id",
             TaskType.RERANK,
             "service",
-            new ElasticInferenceServiceRerankServiceSettings(modelId, null),
+            new ElasticInferenceServiceRerankServiceSettings(modelId),
             EmptyTaskSettings.INSTANCE,
             EmptySecretSettings.INSTANCE,
             ElasticInferenceServiceComponents.of(url)

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/rerank/ElasticInferenceServiceRerankServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/rerank/ElasticInferenceServiceRerankServiceSettingsTests.java
@@ -7,12 +7,15 @@
 
 package org.elasticsearch.xpack.inference.services.elastic.rerank;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
@@ -21,9 +24,12 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 
-public class ElasticInferenceServiceRerankServiceSettingsTests extends AbstractWireSerializingTestCase<
+public class ElasticInferenceServiceRerankServiceSettingsTests extends AbstractBWCWireSerializationTestCase<
     ElasticInferenceServiceRerankServiceSettings> {
 
     @Override
@@ -50,27 +56,90 @@ public class ElasticInferenceServiceRerankServiceSettingsTests extends AbstractW
             ConfigurationParseContext.REQUEST
         );
 
-        assertThat(serviceSettings, is(new ElasticInferenceServiceRerankServiceSettings(modelId, null)));
+        assertThat(serviceSettings, is(new ElasticInferenceServiceRerankServiceSettings(modelId)));
+        assertThat(serviceSettings.rateLimitSettings(), sameInstance(RateLimitSettings.DISABLED_INSTANCE));
+    }
+
+    public void testFromMap_DoesNotRemoveRateLimitField_DoesNotThrowValidationException_PersistentContext() {
+        var modelId = "my-model-id";
+
+        var map = new HashMap<String, Object>(
+            Map.of(
+                ServiceFields.MODEL_ID,
+                modelId,
+                RateLimitSettings.FIELD_NAME,
+                new HashMap<>(Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))
+            )
+        );
+
+        var serviceSettings = ElasticInferenceServiceRerankServiceSettings.fromMap(map, ConfigurationParseContext.PERSISTENT);
+
+        assertThat(serviceSettings, is(new ElasticInferenceServiceRerankServiceSettings(modelId)));
+        assertThat(map, is(Map.of(RateLimitSettings.FIELD_NAME, Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))));
+        assertThat(serviceSettings.rateLimitSettings(), sameInstance(RateLimitSettings.DISABLED_INSTANCE));
+    }
+
+    public void testFromMap_DoesNotThrowValidationException_WhenRateLimitFieldDoesNotExist() {
+        var modelId = "my-model-id";
+
+        var map = new HashMap<String, Object>(Map.of(ServiceFields.MODEL_ID, modelId));
+
+        var serviceSettings = ElasticInferenceServiceRerankServiceSettings.fromMap(map, ConfigurationParseContext.REQUEST);
+
+        assertThat(serviceSettings, is(new ElasticInferenceServiceRerankServiceSettings(modelId)));
+        assertThat(map, anEmptyMap());
+        assertThat(serviceSettings.rateLimitSettings(), sameInstance(RateLimitSettings.DISABLED_INSTANCE));
+    }
+
+    public void testFromMap_DoesThrowValidationException_WhenRateLimitFieldDoesExist_RequestContext() {
+        var modelId = "my-model-id";
+
+        var map = new HashMap<String, Object>(
+            Map.of(
+                ServiceFields.MODEL_ID,
+                modelId,
+                RateLimitSettings.FIELD_NAME,
+                new HashMap<>(Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))
+            )
+        );
+
+        var exception = expectThrows(
+            ValidationException.class,
+            () -> ElasticInferenceServiceRerankServiceSettings.fromMap(map, ConfigurationParseContext.REQUEST)
+        );
+
+        assertThat(
+            exception.getMessage(),
+            containsString("[service_settings] rate limit settings are not permitted for service [elastic] and task type [rerank]")
+        );
+        assertThat(map, is(Map.of(RateLimitSettings.FIELD_NAME, Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))));
     }
 
     public void testToXContent_WritesAllFields() throws IOException {
         var modelId = ".rerank-v1";
-        var rateLimitSettings = new RateLimitSettings(100L);
-        var serviceSettings = new ElasticInferenceServiceRerankServiceSettings(modelId, rateLimitSettings);
+        var serviceSettings = new ElasticInferenceServiceRerankServiceSettings(modelId);
 
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
         serviceSettings.toXContent(builder, null);
         String xContentResult = Strings.toString(builder);
 
-        assertThat(xContentResult, is(Strings.format("""
-            {"model_id":"%s","rate_limit":{"requests_per_minute":%d}}""", modelId, rateLimitSettings.requestsPerTimeUnit())));
+        assertThat(xContentResult, is(XContentHelper.stripWhitespace(Strings.format("""
+            {"model_id":"%s"}""", modelId))));
     }
 
     public static ElasticInferenceServiceRerankServiceSettings createRandom() {
-        return new ElasticInferenceServiceRerankServiceSettings(randomRerankModel(), null);
+        return new ElasticInferenceServiceRerankServiceSettings(randomRerankModel());
     }
 
     private static String randomRerankModel() {
         return randomFrom(".rerank-v1", ".rerank-v2");
+    }
+
+    @Override
+    protected ElasticInferenceServiceRerankServiceSettings mutateInstanceForVersion(
+        ElasticInferenceServiceRerankServiceSettings instance,
+        TransportVersion version
+    ) {
+        return instance;
     }
 }


### PR DESCRIPTION
This PR disables the rate limiting settings within the inference API for EIS for **all** task types.

This PR does not change the default inference endpoints that were persisted to the `.inference` index. Instead, the changes make all default and new EIS inference endpoints have rate limiting disabled.

The changes no longer parse the `rate_limit` field. If a PUT request includes the `rate_limit` field we'll throw a validation exception indicating that it shouldn't be included.

The field will be ignored if coming from the `.inference` index.

Another option would be to return and store:

```
"rate_limit": {
    "enabled": false
}
```

If we think that'd be more clear to the user.

**I don't think many users are creating EIS endpoints because it isn't documented so maybe this isn't an issue.**

## Example

```
PUT 
{
    "service": "elastic",
    "service_settings": {
        "model_id": "elser-2",
        "rate_limit": {
            "requests_per_minute": 200
        }
    }
}
```

The result will no longer include the `rate_limit` field since rate limiting is no longer supported.

Response
```
{
    "inference_id": "test",
    "task_type": "sparse_embedding",
    "service": "elastic",
    "service_settings": {
        "model_id": "elser-2"
    },
    "chunking_settings": {
        "strategy": "sentence",
        "max_chunk_size": 250,
        "sentence_overlap": 1
    }
}
```