### PR TITLE
Mirror upstream elastic/elasticsearch#134359 for AI review (snapshot of HEAD tree)

### DIFF
--- a/docs/changelog/134359.yaml
+++ b/docs/changelog/134359.yaml
@@ -1,0 +1,6 @@
+pr: 134359
+summary: Make `MutableSearchResponse` ref-counted to prevent use-after-close in async
+  search
+area: Search
+type: bug
+issues: []

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchConcurrentStatusIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchConcurrentStatusIT.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.search;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.test.ESIntegTestCase.SuiteScopeTestCase;
+import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.IntStream;
+
+@SuiteScopeTestCase
+public class AsyncSearchConcurrentStatusIT extends AsyncSearchIntegTestCase {
+    private static String indexName;
+    private static int numShards;
+
+    private static int numKeywords;
+
+    @Override
+    public void setupSuiteScopeCluster() {
+        indexName = "test-async";
+        numShards = randomIntBetween(1, 20);
+        int numDocs = randomIntBetween(100, 1000);
+        createIndex(indexName, Settings.builder().put("index.number_of_shards", numShards).build());
+        numKeywords = randomIntBetween(50, 100);
+        Set<String> keywordSet = new HashSet<>();
+        for (int i = 0; i < numKeywords; i++) {
+            keywordSet.add(randomAlphaOfLengthBetween(10, 20));
+        }
+        numKeywords = keywordSet.size();
+        String[] keywords = keywordSet.toArray(String[]::new);
+        List<IndexRequestBuilder> reqs = new ArrayList<>();
+        for (int i = 0; i < numDocs; i++) {
+            float metric = randomFloat();
+            String keyword = keywords[randomIntBetween(0, numKeywords - 1)];
+            reqs.add(prepareIndex(indexName).setSource("terms", keyword, "metric", metric));
+        }
+        indexRandom(true, true, reqs);
+    }
+
+    /**
+     * This test spins up a set of poller threads that repeatedly call
+     * {@code _async_search/{id}}. Each poller starts immediately, and once enough
+     * requests have been issued they signal a latch to indicate the group is "warmed up".
+     * The test waits on this latch to deterministically ensure pollers are active.
+     * In parallel, a consumer thread drives the async search to completion using the
+     * blocking iterator. This coordinated overlap exercises the window where the task
+     * is closing and some status calls may return {@code 410 GONE}.
+     */
+    public void testConcurrentStatusFetchWhileTaskCloses() throws Exception {
+        final TimeValue timeout = TimeValue.timeValueSeconds(3);
+        final String aggName = "terms";
+        final SearchSourceBuilder source = new SearchSourceBuilder().aggregation(
+            AggregationBuilders.terms(aggName).field("terms.keyword").size(Math.max(1, numKeywords))
+        );
+
+        final int progressStep = (numShards > 2) ? randomIntBetween(2, numShards) : 2;
+        try (SearchResponseIterator it = assertBlockingIterator(indexName, numShards, source, 0, progressStep)) {
+            String id = getAsyncId(it);
+
+            PollStats stats = new PollStats();
+
+            // Pick a random number of status-poller threads, at least 1, up to (4×numShards)
+            int pollerThreads = randomIntBetween(1, 4 * numShards);
+
+            // Wait for pollers to be active
+            CountDownLatch warmed = new CountDownLatch(1);
+
+            // Executor and coordination for pollers
+            ExecutorService pollerExec = Executors.newFixedThreadPool(pollerThreads);
+            AtomicBoolean running = new AtomicBoolean(true);
+            Queue<Throwable> failures = new ConcurrentLinkedQueue<>();
+
+            CompletableFuture<Void> pollers = createPollers(id, pollerThreads, stats, warmed, pollerExec, running, failures);
+
+            // Wait until pollers are issuing requests (warming period)
+            assertTrue("pollers did not warm up in time", warmed.await(timeout.millis(), TimeUnit.MILLISECONDS));
+
+            // Start consumer on a separate thread and capture errors
+            var consumerExec = Executors.newSingleThreadExecutor();
+            AtomicReference<Throwable> consumerError = new AtomicReference<>();
+            Future<?> consumer = consumerExec.submit(() -> {
+                try {
+                    consumeAllResponses(it, aggName);
+                } catch (Throwable t) {
+                    consumerError.set(t);
+                }
+            });
+
+            // Join consumer & surface errors
+            try {
+                consumer.get(timeout.millis(), TimeUnit.MILLISECONDS);
+
+                if (consumerError.get() != null) {
+                    fail("consumeAllResponses failed: " + consumerError.get());
+                }
+            } catch (TimeoutException e) {
+                consumer.cancel(true);
+                fail(e, "Consumer thread did not finish within timeout");
+            } catch (Exception ignored) {
+                // ignored
+            } finally {
+                // Stop pollers
+                running.set(false);
+                try {
+                    pollers.get(timeout.millis(), TimeUnit.MILLISECONDS);
+                } catch (TimeoutException te) {
+                    // The finally block will shut down the pollers forcibly
+                } catch (ExecutionException ee) {
+                    failures.add(ExceptionsHelper.unwrapCause(ee.getCause()));
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    pollerExec.shutdownNow();
+                    try {
+                        pollerExec.awaitTermination(timeout.millis(), TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        fail("Interrupted while stopping pollers: " + ie.getMessage());
+                    }
+                }
+
+                // Shut down the consumer executor
+                consumerExec.shutdown();
+                try {
+                    consumerExec.awaitTermination(timeout.millis(), TimeUnit.MILLISECONDS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            assertNoWorkerFailures(failures);
+            assertStats(stats);
+        }
+    }
+
+    private void assertNoWorkerFailures(Queue<Throwable> failures) {
+        assertTrue(
+            "Unexpected worker failures:\n" + failures.stream().map(ExceptionsHelper::stackTrace).reduce("", (a, b) -> a + "\n---\n" + b),
+            failures.isEmpty()
+        );
+    }
+
+    private void assertStats(PollStats stats) {
+        assertEquals(stats.totalCalls.sum(), stats.runningResponses.sum() + stats.completedResponses.sum());
+        assertEquals("There should be no exceptions other than GONE", 0, stats.exceptions.sum());
+    }
+
+    private String getAsyncId(SearchResponseIterator it) {
+        AsyncSearchResponse response = it.next();
+        try {
+            assertNotNull(response.getId());
+            return response.getId();
+        } finally {
+            response.decRef();
+        }
+    }
+
+    private void consumeAllResponses(SearchResponseIterator it, String aggName) throws Exception {
+        while (it.hasNext()) {
+            AsyncSearchResponse response = it.next();
+            try {
+                if (response.getSearchResponse() != null && response.getSearchResponse().getAggregations() != null) {
+                    assertNotNull(response.getSearchResponse().getAggregations().get(aggName));
+                }
+            } finally {
+                response.decRef();
+            }
+        }
+    }
+
+    private CompletableFuture<Void> createPollers(
+        String id,
+        int threads,
+        PollStats stats,
+        CountDownLatch warmed,
+        ExecutorService pollerExec,
+        AtomicBoolean running,
+        Queue<Throwable> failures
+    ) {
+        @SuppressWarnings("unchecked")
+        final CompletableFuture<Void>[] tasks = IntStream.range(0, threads).mapToObj(i -> CompletableFuture.runAsync(() -> {
+            while (running.get()) {
+                AsyncSearchResponse resp = null;
+                try {
+                    resp = getAsyncSearch(id);
+                    stats.totalCalls.increment();
+
+                    // Once enough requests have been sent, consider pollers "warmed".
+                    if (stats.totalCalls.sum() >= threads) {
+                        warmed.countDown();
+                    }
+
+                    if (resp.isRunning()) {
+                        stats.runningResponses.increment();
+                    } else {
+                        // Success-only assertions: if reported completed, we must have a proper search response
+                        assertNull("Async search reported completed with failure", resp.getFailure());
+                        assertNotNull("Completed async search must carry a SearchResponse", resp.getSearchResponse());
+                        assertNotNull("Completed async search must have aggregations", resp.getSearchResponse().getAggregations());
+                        assertNotNull(
+                            "Completed async search must contain the expected aggregation",
+                            resp.getSearchResponse().getAggregations().get("terms")
+                        );
+                        stats.completedResponses.increment();
+                    }
+                } catch (Exception e) {
+                    Throwable cause = ExceptionsHelper.unwrapCause(e);
+                    if (cause instanceof ElasticsearchStatusException) {
+                        RestStatus status = ExceptionsHelper.status(cause);
+                        if (status == RestStatus.GONE) {
+                            stats.gone410.increment();
+                        } else {
+                            stats.exceptions.increment();
+                            failures.add(cause);
+                        }
+                    } else {
+                        stats.exceptions.increment();
+                        failures.add(cause);
+                    }
+                } finally {
+                    if (resp != null) {
+                        resp.decRef();
+                    }
+                }
+            }
+        }, pollerExec).whenComplete((v, ex) -> {
+            if (ex != null) {
+                failures.add(ExceptionsHelper.unwrapCause(ex));
+            }
+        })).toArray(CompletableFuture[]::new);
+
+        return CompletableFuture.allOf(tasks);
+    }
+
+    static final class PollStats {
+        final LongAdder totalCalls = new LongAdder();
+        final LongAdder runningResponses = new LongAdder();
+        final LongAdder completedResponses = new LongAdder();
+        final LongAdder exceptions = new LongAdder();
+        final LongAdder gone410 = new LongAdder();
+    }
+}

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchRefcountAndFallbackTests.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchRefcountAndFallbackTests.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.search;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.aggregations.AggregationReduceContext;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.async.AsyncExecutionId;
+import org.elasticsearch.xpack.core.async.AsyncTaskIndexService;
+import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+public class AsyncSearchRefcountAndFallbackTests extends ESSingleNodeTestCase {
+
+    private AsyncTaskIndexService<AsyncSearchResponse> store;
+    public String index = ".async-search";
+
+    private TestThreadPool threadPool;
+    private NoOpClient client;
+
+    final int totalShards = 1;
+    final int skippedShards = 0;
+
+    @Before
+    public void setup() {
+        this.threadPool = new TestThreadPool(getTestName());
+        this.client = new NoOpClient(threadPool);
+
+        ClusterService clusterService = getInstanceFromNode(ClusterService.class);
+        TransportService transportService = getInstanceFromNode(TransportService.class);
+        BigArrays bigArrays = getInstanceFromNode(BigArrays.class);
+        this.store = new AsyncTaskIndexService<>(
+            index,
+            clusterService,
+            transportService.getThreadPool().getThreadContext(),
+            client(),
+            "test_origin",
+            AsyncSearchResponse::new,
+            writableRegistry(),
+            bigArrays
+        );
+    }
+
+    @After
+    public void cleanup() {
+        terminate(threadPool);
+    }
+
+    /**
+     * If another thread still holds a ref to the in-memory MutableSearchResponse,
+     * building an AsyncSearchResponse succeeds (final SearchResponse is still live).
+     */
+    public void testBuildSucceedsIfAnotherThreadHoldsRef() {
+        // Build a SearchResponse (sr refCount -> 1)
+        SearchResponse searchResponse = createSearchResponse(totalShards, totalShards, skippedShards);
+
+        // Take a ref - (msr refCount -> 1, sr refCount -> 2)
+        MutableSearchResponse msr = new MutableSearchResponse(threadPool.getThreadContext());
+        msr.updateShardsAndClusters(totalShards, skippedShards, null);
+        msr.updateFinalResponse(searchResponse, false);
+
+        searchResponse.decRef(); // sr refCount -> 1
+
+        // Simulate another thread : take a resource (msr refCount -> 2)
+        msr.incRef();
+        // close resource (msr refCount -> 1) -> closeInternal not called yet
+        msr.decRef();
+
+        // Build a response
+        AsyncSearchResponse resp = msr.toAsyncSearchResponse(createAsyncSearchTask(), System.currentTimeMillis() + 60_000, false);
+        try {
+            assertNotNull("Expect SearchResponse when a live ref prevents close", resp.getSearchResponse());
+            assertNull("No failure expected while ref is held", resp.getFailure());
+            assertFalse("Response should not be marked running", resp.isRunning());
+        } finally {
+            resp.decRef();
+        }
+
+        // Release msr (msr refCount -> 0, sr refCount -> 0) -> now calling closeInternal
+        msr.decRef();
+    }
+
+    /**
+     * When the in-memory MutableSearchResponse has been released (tryIncRef == false),
+     * the task falls back to the async-search store and returns the persisted response (200 OK).
+     */
+    public void testFallbackToStoreWhenInMemoryResponseReleased() throws Exception {
+        // Create an AsyncSearchTask
+        AsyncSearchTask task = createAsyncSearchTask();
+        assertNotNull(task);
+
+        // Build a SearchResponse (ssr refCount -> 1) to be stored in the index
+        SearchResponse storedSearchResponse = createSearchResponse(totalShards, totalShards, skippedShards);
+
+        // Take a ref - (msr refCount -> 1, ssr refCount -> 2)
+        MutableSearchResponse msr = task.getSearchResponse();
+        msr.updateShardsAndClusters(totalShards, skippedShards, /*clusters*/ null);
+        msr.updateFinalResponse(storedSearchResponse, /*ccsMinimizeRoundtrips*/ false);
+
+        // Build the AsyncSearchResponse to persist in the store
+        AsyncSearchResponse asyncSearchResponse = null;
+        try {
+            long now = System.currentTimeMillis();
+            asyncSearchResponse = new AsyncSearchResponse(
+                task.getExecutionId().getEncoded(),
+                storedSearchResponse,
+                /*failure*/ null,
+                /*isPartial*/ false,
+                /*isRunning*/ false,
+                task.getStartTime(),
+                now + TimeValue.timeValueMinutes(1).millis()
+            );
+        } finally {
+            if (asyncSearchResponse != null) {
+                // (ssr refCount -> 2, asr refCount -> 0)
+                asyncSearchResponse.decRef();
+            }
+        }
+
+        // Persist initial/final response to the store while we still hold a ref
+        PlainActionFuture<DocWriteResponse> write = new PlainActionFuture<>();
+        store.createResponse(task.getExecutionId().getDocId(), Map.of(), asyncSearchResponse, write);
+        write.actionGet();
+
+        // Release the in-memory objects so the task path must fall back to the store
+        // - drop our extra ref to the SearchResponse that updateFinalResponse() took (sr -> 1)
+        storedSearchResponse.decRef();
+        // - drop the in-memory MutableSearchResponse so mutableSearchResponse.tryIncRef() == false
+        // msr -> 0 (closeInternal runs, releasing its ssr) → tryIncRef() will now fail
+        msr.decRef();
+
+        PlainActionFuture<AsyncSearchResponse> future = new PlainActionFuture<>();
+        task.getResponse(future);
+
+        AsyncSearchResponse resp = future.actionGet();
+        assertNotNull("Expected response loaded from store", resp);
+        assertNull("No failure expected when loaded from store", resp.getFailure());
+        assertNotNull("SearchResponse must be present", resp.getSearchResponse());
+        assertFalse("Should not be running", resp.isRunning());
+        assertFalse("Should not be partial", resp.isPartial());
+        assertEquals(RestStatus.OK, resp.status());
+    }
+
+    /**
+     * When both the in-memory MutableSearchResponse has been released AND the stored
+     * document has been deleted or not found, the task returns GONE (410).
+     */
+    public void testGoneWhenInMemoryReleasedAndStoreMissing() throws Exception {
+        AsyncSearchTask task = createAsyncSearchTask();
+
+        SearchResponse searchResponse = createSearchResponse(totalShards, totalShards, skippedShards);
+        MutableSearchResponse msr = task.getSearchResponse();
+        msr.updateShardsAndClusters(totalShards, skippedShards, null);
+        msr.updateFinalResponse(searchResponse, false);
+
+        long now = System.currentTimeMillis();
+        AsyncSearchResponse asr = new AsyncSearchResponse(
+            task.getExecutionId().getEncoded(),
+            searchResponse,
+            null,
+            false,
+            false,
+            task.getStartTime(),
+            now + TimeValue.timeValueMinutes(1).millis()
+        );
+        asr.decRef();
+
+        PlainActionFuture<DocWriteResponse> write = new PlainActionFuture<>();
+        store.createResponse(task.getExecutionId().getDocId(), Map.of(), asr, write);
+        write.actionGet();
+
+        searchResponse.decRef();
+        msr.decRef();
+
+        // Delete the doc from store
+        PlainActionFuture<DeleteResponse> del = new PlainActionFuture<>();
+        store.deleteResponse(task.getExecutionId(), del);
+        del.actionGet();
+
+        // Now the task must surface GONE
+        PlainActionFuture<AsyncSearchResponse> future = new PlainActionFuture<>();
+        task.getResponse(future);
+
+        Exception ex = expectThrows(Exception.class, future::actionGet);
+        Throwable cause = ExceptionsHelper.unwrapCause(ex);
+        assertThat(cause, instanceOf(ElasticsearchStatusException.class));
+        assertThat(ExceptionsHelper.status(cause), is(RestStatus.GONE));
+    }
+
+    private AsyncSearchTask createAsyncSearchTask() {
+        return new AsyncSearchTask(
+            1L,
+            "search",
+            "indices:data/read/search",
+            TaskId.EMPTY_TASK_ID,
+            () -> "debug",
+            TimeValue.timeValueMinutes(1),
+            Map.of(),
+            Map.of(),
+            new AsyncExecutionId("debug", new TaskId("node", 1L)),
+            client,
+            threadPool,
+            isCancelled -> () -> new AggregationReduceContext.ForFinal(null, null, null, null, null, PipelineAggregator.PipelineTree.EMPTY),
+            store
+        );
+    }
+
+    private SearchResponse createSearchResponse(int totalShards, int successfulShards, int skippedShards) {
+        SearchResponse.Clusters clusters = new SearchResponse.Clusters(1, 1, 0);
+        return new SearchResponse(
+            SearchHits.empty(Lucene.TOTAL_HITS_GREATER_OR_EQUAL_TO_ZERO, Float.NaN),
+            null,
+            null,
+            false,
+            false,
+            null,
+            0,
+            null,
+            totalShards,
+            successfulShards,
+            skippedShards,
+            1L,
+            ShardSearchFailure.EMPTY_ARRAY,
+            clusters
+        );
+    }
+}

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -19,7 +19,7 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -40,7 +40,7 @@ import static org.elasticsearch.xpack.core.async.AsyncTaskIndexService.restoreRe
  * creating an async response concurrently. This limits the number of final reduction that can
  * run concurrently to 1 and ensures that we pause the search progress when an {@link AsyncSearchResponse} is built.
  */
-class MutableSearchResponse implements Releasable {
+class MutableSearchResponse extends AbstractRefCounted {
 
     private final Logger logger = Loggers.getLogger(getClass(), "async");
 
@@ -90,6 +90,7 @@ class MutableSearchResponse implements Releasable {
      * @param threadContext The thread context to retrieve the final response headers.
      */
     MutableSearchResponse(ThreadContext threadContext) {
+        super();
         this.isPartial = true;
         this.threadContext = threadContext;
         this.totalHits = Lucene.TOTAL_HITS_GREATER_OR_EQUAL_TO_ZERO;
@@ -492,7 +493,8 @@ class MutableSearchResponse implements Releasable {
     }
 
     @Override
-    public synchronized void close() {
+    protected synchronized void closeInternal() {
+
         if (logger.isDebugEnabled()) {
             logger.debug(
                 "MutableSearchResponse.close(): byThread={}, finalResponsePresent={}, clusterResponsesCount={}, stack={}",
@@ -505,11 +507,14 @@ class MutableSearchResponse implements Releasable {
 
         if (finalResponse != null) {
             finalResponse.decRef();
+            finalResponse = null;
         }
         if (clusterResponses != null) {
             for (SearchResponse clusterResponse : clusterResponses) {
                 clusterResponse.decRef();
             }
+            clusterResponses.clear();
+            clusterResponses = null;
         }
     }
 }

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
@@ -207,7 +207,8 @@ public class TransportSubmitAsyncSearchAction extends HandledTransportAction<Sub
                     store.getClientWithOrigin(),
                     nodeClient.threadPool(),
                     isCancelled -> () -> searchService.aggReduceContextBuilder(isCancelled, originalSearchRequest.source().aggregations())
-                        .forFinalReduction()
+                        .forFinalReduction(),
+                    store
                 );
             }
         };

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchTaskTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchTaskTests.java
@@ -91,7 +91,8 @@ public class AsyncSearchTaskTests extends ESTestCase {
             new AsyncExecutionId("0", new TaskId("node1", 1)),
             new NoOpClient(threadPool),
             threadPool,
-            (t) -> () -> null
+            (t) -> () -> null,
+            null
         );
     }
 
@@ -112,7 +113,8 @@ public class AsyncSearchTaskTests extends ESTestCase {
                 new AsyncExecutionId("0", new TaskId("node1", 1)),
                 new NoOpClient(threadPool),
                 threadPool,
-                (t) -> () -> null
+                (t) -> () -> null,
+                null
             )
         ) {
             assertEquals("""
@@ -135,7 +137,8 @@ public class AsyncSearchTaskTests extends ESTestCase {
                 new AsyncExecutionId("0", new TaskId("node1", 1)),
                 new NoOpClient(threadPool),
                 threadPool,
-                (t) -> () -> null
+                (t) -> () -> null,
+                null
             )
         ) {
             int numShards = randomIntBetween(0, 10);


### PR DESCRIPTION
The current implementation of `MutableSearchResponse.toAsyncSearchResponse()` assumes that if `finalResponse != null`, the `SearchResponse` can always be retained. It enforces this by calling `mustIncRef()`.

However, under concurrent execution, this assumption breaks down. One thread may be serializing a response while another (via AsyncSearchTask.close()) decrements the reference count. If `decRef()` drops the count to `0`, the object is released. A later `mustIncRef()` will then fail, leading to assertion errors or use-after-release. This creates a race condition that can cause sporadic failures when fetching async search results, especially in the narrow window between task closure and document deletion.

This PR intends to improve the safety of `MutableSearchResponse` under concurrent access. The goal is 

- Allow a thread that is already building a response to complete and return it.
- Prevent subsequent calls from accessing the resource once it has been closed/released.

To achieve this, the `MutableSearchResponse` is now ref-counted. Any thread building a response must first successfully acquire a reference. If the container (msr) has already been released, the attempt fails with a `GONE` status instead of tripping assertions. Finally the `AsyncSearchTask#getResponse` holds and releases the `msr` explicitly to prevent use-after-close races.