### PR TITLE
Mirror upstream elastic/elasticsearch#137511 for AI review (snapshot of HEAD tree)

### DIFF
--- a/docs/changelog/137511.yaml
+++ b/docs/changelog/137511.yaml
@@ -1,0 +1,5 @@
+pr: 137511
+summary: Fixes esql class cast bug in STATS at planning level
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -3463,3 +3463,89 @@ employees:long | job_positions:keyword
 15             | Tech Lead    
 ;
 
+fixClassCastBug
+required_capability: fix_stats_classcast_exception
+
+from airports 
+| rename scalerank AS x 
+| stats  a = count(x), b = count(x) + count(x), c = count_distinct(x)
+;
+
+a:long | b:long | c:long
+891    | 1782   | 8
+;
+
+fixClassCastBug2
+required_capability: fix_stats_classcast_exception
+
+ROW x = [1,2,3] 
+| STATS a = MV_COUNT(VALUES(x)), b = VALUES(x), c = SUM(x)
+;
+
+a:integer | b:integer | c:long
+3         | [1, 2, 3] | 6
+;
+
+fixClassCastBug3
+required_capability: fix_stats_classcast_exception
+
+ROW x = 1 
+| STATS a = 2*COUNT_DISTINCT(x), b = COUNT_DISTINCT(x), c = MAX(x)
+;
+
+a:long | b:long | c:integer
+2      | 1      | 1
+;
+
+fixClassCastBug4
+required_capability: inline_stats
+required_capability: fix_stats_classcast_exception
+
+FROM sample_data, sample_data_str
+| EVAL one_ip = client_ip::ip
+| INLINE STATS count1=count(client_ip::ip), count2=count(one_ip)
+| KEEP count1, count2
+| LIMIT 3
+;
+
+count1:long    |count2:long
+14             |14 
+14             |14 
+14             |14
+;
+
+fixClassCastBug5
+required_capability: fix_stats_classcast_exception
+
+FROM sample_data_ts_long 
+| EVAL sym1 = 0, sym5 = 1
+| STATS sym2 = median(sym5) + 0, sym3 = median(sym5), sym4 = count_distinct(sym1)
+;
+
+sym2:double |sym3:double | sym4:long
+1.0         | 1.0        | 1
+;
+
+fixClassCastBug6
+required_capability: fix_stats_classcast_exception
+
+from airports 
+| rename scalerank AS x 
+| stats  a = count(x), b = count(x) + count(x), c = count_distinct(x, 10), d = count_distinct(x, 10 + 1 - 1)
+;
+
+a:long | b:long | c:long | d:long
+891    | 1782   | 8      | 8
+;
+
+fixClassCastBug7
+required_capability: fix_stats_classcast_exception
+
+from airports 
+| rename scalerank AS x 
+| stats a = median(x), b = percentile(x, 50), c = count_distinct(x)
+;
+
+a:double | b:double | c:long
+6.0      | 6.0      | 8
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1580,6 +1580,13 @@ public class EsqlCapabilities {
         PUSHING_DOWN_EVAL_WITH_SCORE,
 
         /**
+         * Fix for ClassCastException in STATS
+         * https://github.com/elastic/elasticsearch/issues/133992
+         * https://github.com/elastic/elasticsearch/issues/136598
+         */
+        FIX_STATS_CLASSCAST_EXCEPTION,
+
+        /**
          * Fix attribute equality to respect the name id of the attribute.
          */
         ATTRIBUTE_EQUALS_RESPECTS_NAME_ID,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -54,6 +54,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.logical.RemoveStatsOverride;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceAggregateAggExpressionWithEval;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceAggregateNestedExpressionWithEval;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceAliasingEvalWithProject;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceDuplicatedAggs;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceLimitAndSortAsTopN;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceOrderByExpressionWithEval;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceRegexMatch;
@@ -178,6 +179,8 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
             new SplitInWithFoldableValue(),
             new PropagateEvalFoldables(),
             new ConstantFolding(),
+            // then extract nested aggs top-level
+            new ReplaceDuplicatedAggs(),
             new PartiallyFoldCase(),
             // boolean
             new BooleanSimplification(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceDuplicatedAggs.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceDuplicatedAggs.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
-import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
@@ -18,33 +17,21 @@ import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.grouping.GroupingFunction;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
-import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Replace nested expressions over aggregates with synthetic eval post the aggregation
- * stats a = sum(a) + min(b) by x
- * becomes
- * stats a1 = sum(a), a2 = min(b) by x | eval a = a1 + a2 | keep a, x
- * The rule also considers expressions applied over groups:
- * {@code STATS a = x + 1 BY x} becomes {@code STATS BY x | EVAL a = x + 1 | KEEP a, x}
- * And to combine the two:
- * stats a = x + count(*) by x
- * becomes
- * stats a1 = count(*) by x | eval a = x + a1 | keep a1, x
- * Since the logic is very similar, this rule also handles duplicate aggregate functions to avoid duplicate compute
+ * This rule handles duplicate aggregate functions to avoid duplicate compute
  * stats a = min(x), b = min(x), c = count(*), d = count() by g
  * becomes
  * stats a = min(x), c = count(*) by g | eval b = a, d = c | keep a, b, c, d, g
  */
-public final class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.OptimizerRule<Aggregate> {
-    public ReplaceAggregateAggExpressionWithEval() {
+public final class ReplaceDuplicatedAggs extends OptimizerRules.OptimizerRule<Aggregate> implements OptimizerRules.CoordinatorOnly {
+    public ReplaceDuplicatedAggs() {
         super(OptimizerRules.TransformDirection.UP);
     }
 
@@ -52,14 +39,8 @@ public final class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.
     protected LogicalPlan rule(Aggregate aggregate) {
         // an alias map for evaluatable grouping functions
         AttributeMap.Builder<Expression> aliasesBuilder = AttributeMap.builder();
-        // a function map for non-evaluatable grouping functions
-        Map<GroupingFunction.NonEvaluatableGroupingFunction, Attribute> nonEvalGroupingAttributes = new HashMap<>(
-            aggregate.groupings().size()
-        );
         aggregate.forEachExpressionUp(Alias.class, a -> {
-            if (a.child() instanceof GroupingFunction.NonEvaluatableGroupingFunction groupingFunction) {
-                nonEvalGroupingAttributes.put(groupingFunction, a.toAttribute());
-            } else {
+            if (a.child() instanceof GroupingFunction.NonEvaluatableGroupingFunction == false) {
                 aliasesBuilder.put(a.toAttribute(), a.child());
             }
         });
@@ -71,14 +52,11 @@ public final class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.
 
         // root/naked aggs
         Map<AggregateFunction, Alias> rootAggs = Maps.newLinkedHashMapWithExpectedSize(aggs.size());
-        // evals (original expression relying on multiple aggs)
-        List<Alias> newEvals = new ArrayList<>();
         List<NamedExpression> newProjections = new ArrayList<>();
         // track the aggregate aggs (including grouping which is not an AggregateFunction)
         List<NamedExpression> newAggs = new ArrayList<>();
 
         Holder<Boolean> changed = new Holder<>(false);
-        int[] counter = new int[] { 0 };
 
         for (NamedExpression agg : aggs) {
             if (agg instanceof Alias as) {
@@ -88,7 +66,7 @@ public final class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.
                 // common case - handle duplicates
                 if (child instanceof AggregateFunction af) {
                     // canonical representation, with resolved aliases
-                    AggregateFunction canonical = (AggregateFunction) af.canonical().transformUp(e -> aliases.resolve(e, e));
+                    AggregateFunction canonical = (AggregateFunction) af.transformUp(e -> aliases.resolve(e, e));
 
                     Alias found = rootAggs.get(canonical);
                     // aggregate is new
@@ -104,36 +82,6 @@ public final class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.
                         newProjections.add(as.replaceChild(found.toAttribute()));
                     }
                 }
-                // nested expression over aggregate function or groups
-                // replace them with reference and move the expression into a follow-up eval
-                else {
-                    changed.set(true);
-                    Expression aggExpression = child.transformUp(AggregateFunction.class, af -> {
-                        // canonical representation, with resolved aliases
-                        AggregateFunction canonical = (AggregateFunction) af.canonical().transformUp(e -> aliases.resolve(e, e));
-                        Alias alias = rootAggs.get(canonical);
-                        if (alias == null) {
-                            // create synthetic alias ove the found agg function
-                            alias = new Alias(af.source(), syntheticName(canonical, child, counter[0]++), af, null, true);
-                            // and remember it to remove duplicates
-                            rootAggs.put(canonical, alias);
-                            // add it to the list of aggregates and continue
-                            newAggs.add(alias);
-                        }
-                        // (even when found) return a reference to it
-                        return alias.toAttribute();
-                    });
-
-                    // replace non-evaluatable grouping functions with their references
-                    aggExpression = aggExpression.transformUp(
-                        GroupingFunction.NonEvaluatableGroupingFunction.class,
-                        nonEvalGroupingAttributes::get
-                    );
-
-                    Alias alias = as.replaceChild(aggExpression);
-                    newEvals.add(alias);
-                    newProjections.add(alias.toAttribute());
-                }
             }
             // not an alias (e.g. grouping field)
             else {
@@ -146,17 +94,10 @@ public final class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.
         if (changed.get()) {
             Source source = aggregate.source();
             plan = aggregate.with(aggregate.child(), aggregate.groupings(), newAggs);
-            if (newEvals.size() > 0) {
-                plan = new Eval(source, plan, newEvals);
-            }
             // preserve initial projection
             plan = new Project(source, plan, newProjections);
         }
 
         return plan;
-    }
-
-    private static String syntheticName(Expression expression, Expression af, int counter) {
-        return TemporaryNameUtils.temporaryName(expression, af, counter);
     }
 }


### PR DESCRIPTION
Addresses https://github.com/elastic/elasticsearch/issues/133992 and https://github.com/elastic/elasticsearch/issues/136598, partially.

Missing from this pr that we still need to do: at the moment the runtime part tries to avoid double computations, resulting in exceptions if the plan is correct but not optimal. In other words, queries like:

```sql
from airports 
rename scalerank AS x 
stats  a = count(x), b = count(x) + count(x), c = count_distinct(x)
```

should had never failed at runtime even if the plan was not optimal for repeated aggregations.