### PR TITLE
Mirror upstream elastic/elasticsearch#137472 for AI review (snapshot of HEAD tree)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/predicate/operator/VectorBinaryOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/predicate/operator/VectorBinaryOperator.java
@@ -14,8 +14,6 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
-import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
 import org.elasticsearch.xpack.esql.plan.logical.BinaryPlan;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.promql.selector.LabelMatcher;
@@ -163,9 +161,7 @@ public abstract class VectorBinaryOperator extends BinaryPlan {
         if (o == null || getClass() != o.getClass()) return false;
         if (super.equals(o)) {
             VectorBinaryOperator that = (VectorBinaryOperator) o;
-            return dropMetricName == that.dropMetricName
-                && Objects.equals(match, that.match)
-                && Objects.equals(binaryOp, that.binaryOp);
+            return dropMetricName == that.dropMetricName && Objects.equals(match, that.match) && Objects.equals(binaryOp, that.binaryOp);
         }
         return false;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/predicate/operator/comparison/VectorBinaryComparison.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/predicate/operator/comparison/VectorBinaryComparison.java
@@ -47,7 +47,14 @@ public class VectorBinaryComparison extends VectorBinaryOperator {
     private final ComparisonOp op;
     private final boolean boolMode;
 
-    public VectorBinaryComparison(Source source, LogicalPlan left, LogicalPlan right, VectorMatch match, boolean boolMode, ComparisonOp op) {
+    public VectorBinaryComparison(
+        Source source,
+        LogicalPlan left,
+        LogicalPlan right,
+        VectorMatch match,
+        boolean boolMode,
+        ComparisonOp op
+    ) {
         super(source, left, right, match, boolMode == false, op);
         this.op = op;
         this.boolMode = boolMode;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -88,13 +88,17 @@ import org.elasticsearch.xpack.esql.plan.logical.inference.InferencePlan;
 import org.elasticsearch.xpack.esql.plan.logical.inference.Rerank;
 import org.elasticsearch.xpack.esql.plan.logical.join.LookupJoin;
 import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
+import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlParams;
 import org.elasticsearch.xpack.esql.plan.logical.show.ShowInfo;
 import org.joni.exception.SyntaxException;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -116,6 +120,9 @@ import static org.elasticsearch.xpack.esql.plan.logical.Enrich.Mode;
  * which change the grammar will need to make changes here as well.
  */
 public class LogicalPlanBuilder extends ExpressionBuilder {
+
+    private static final String TIME = "time", START = "start", END = "end", STEP = "step";
+    private static final Set<String> PROMQL_ALLOWED_PARAMS = Set.of(TIME, START, END, STEP);
 
     /**
      * Maximum number of commands allowed per query
@@ -1219,52 +1226,7 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
     @Override
     public PlanFactory visitPromqlCommand(EsqlBaseParser.PromqlCommandContext ctx) {
         Source source = source(ctx);
-        Map<String, Expression> params = new HashMap<>();
-        String TIME = "time", START = "start", END = "end", STEP = "step";
-        Set<String> allowed = Set.of(TIME, START, END, STEP);
-
-        if (ctx.promqlParam().isEmpty()) {
-            throw new ParsingException(source(ctx), "Parameter [{}] or [{}] is required", STEP, TIME);
-        }
-
-        for (EsqlBaseParser.PromqlParamContext paramCtx : ctx.promqlParam()) {
-            var paramNameCtx = paramCtx.name;
-            String name = paramNameCtx.getText();
-            if (params.containsKey(name)) {
-                throw new ParsingException(source(paramNameCtx), "[{}] already specified", name);
-            }
-            if (allowed.contains(name) == false) {
-                String message = "Unknown parameter [{}]";
-                List<String> similar = StringUtils.findSimilar(name, allowed);
-                if (CollectionUtils.isEmpty(similar) == false) {
-                    message += ", did you mean " + (similar.size() == 1 ? "[" + similar.get(0) + "]" : "any of " + similar) + "?";
-                }
-                throw new ParsingException(source(paramNameCtx), message, name);
-            }
-            String value = paramCtx.value.getText();
-            // TODO: validate and convert the value
-
-        }
-
-        // Validation logic for time parameters
-        Expression time = params.get(TIME);
-        Expression start = params.get(START);
-        Expression end = params.get(END);
-        Expression step = params.get(STEP);
-
-        if (time != null && (start != null || end != null || step != null)) {
-            throw new ParsingException(
-                source,
-                "Specify either [{}] for instant query or [{}}], [{}] or [{}}] for a range query",
-                TIME,
-                STEP,
-                START,
-                END
-            );
-        }
-        if ((start != null || end != null) && step == null) {
-            throw new ParsingException(source, "[{}}] is required alongside [{}}] or [{}}]", STEP, START, END);
-        }
+        PromqlParams params = parsePromqlParams(ctx, source);
 
         // TODO: Perform type and value validation
         var queryCtx = ctx.promqlQueryPart();
@@ -1292,9 +1254,95 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
             throw PromqlParserUtils.adjustParsingException(pe, promqlStartLine, promqlStartColumn);
         }
 
-        return plan -> time != null
-            ? new PromqlCommand(source, plan, promqlPlan, time)
-            : new PromqlCommand(source, plan, promqlPlan, start, end, step);
+        return plan -> new PromqlCommand(source, plan, promqlPlan, params);
     }
 
+    private static PromqlParams parsePromqlParams(EsqlBaseParser.PromqlCommandContext ctx, Source source) {
+        Instant time = null;
+        Instant start = null;
+        Instant end = null;
+        Duration step = null;
+
+        Set<String> paramsSeen = new HashSet<>();
+        for (EsqlBaseParser.PromqlParamContext paramCtx : ctx.promqlParam()) {
+            String name = param(paramCtx.name);
+            if (paramsSeen.add(name) == false) {
+                throw new ParsingException(source(paramCtx.name), "[{}] already specified", name);
+            }
+            Source valueSource = source(paramCtx.value);
+            String valueString = param(paramCtx.value);
+            switch (name) {
+                case TIME -> time = PromqlParserUtils.parseDate(valueSource, valueString);
+                case START -> start = PromqlParserUtils.parseDate(valueSource, valueString);
+                case END -> end = PromqlParserUtils.parseDate(valueSource, valueString);
+                case STEP -> {
+                    try {
+                        step = Duration.ofSeconds(Integer.parseInt(valueString));
+                    } catch (NumberFormatException ignore) {
+                        step = PromqlParserUtils.parseDuration(valueSource, valueString);
+                    }
+                }
+                default -> {
+                    String message = "Unknown parameter [{}]";
+                    List<String> similar = StringUtils.findSimilar(name, PROMQL_ALLOWED_PARAMS);
+                    if (CollectionUtils.isEmpty(similar) == false) {
+                        message += ", did you mean " + (similar.size() == 1 ? "[" + similar.get(0) + "]" : "any of " + similar) + "?";
+                    }
+                    throw new ParsingException(source(paramCtx.name), message, name);
+                }
+            }
+        }
+
+        // Validation logic for time parameters
+        if (time != null) {
+            if (start != null || end != null || step != null) {
+                throw new ParsingException(
+                    source,
+                    "Specify either [{}] for instant query or [{}}], [{}] or [{}}] for a range query",
+                    TIME,
+                    STEP,
+                    START,
+                    END
+                );
+            }
+        } else if (step != null) {
+            if (start != null || end != null) {
+                if (start == null || end == null) {
+                    throw new ParsingException(
+                        source,
+                        "Parameters [{}] and [{}] must either both be specified or both be omitted for a range query",
+                        START,
+                        END
+                    );
+                }
+                if (end.isBefore(start)) {
+                    throw new ParsingException(
+                        source,
+                        "invalid parameter \"end\": end timestamp must not be before start time",
+                        end,
+                        start
+                    );
+                }
+            }
+            if (step.isPositive() == false) {
+                throw new ParsingException(
+                    source,
+                    "invalid parameter \"step\": zero or negative query resolution step widths are not accepted. "
+                        + "Try a positive integer",
+                    step
+                );
+            }
+        } else {
+            throw new ParsingException(source, "Parameter [{}] or [{}] is required", STEP, TIME);
+        }
+        return new PromqlParams(time, start, end, step);
+    }
+
+    private static String param(EsqlBaseParser.PromqlParamContentContext paramCtx) {
+        if (paramCtx.QUOTED_IDENTIFIER() != null) {
+            return AbstractBuilder.unquote(paramCtx.QUOTED_IDENTIFIER().getText());
+        } else {
+            return paramCtx.getText();
+        }
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlExpressionBuilder.java
@@ -173,10 +173,7 @@ class PromqlExpressionBuilder extends PromqlIdentifierBuilder {
                 }
 
                 // Non-literal LogicalPlan
-                throw new ParsingException(
-                    source(ctx),
-                    "Duration must be a constant expression"
-                );
+                throw new ParsingException(source(ctx), "Duration must be a constant expression");
             }
             case Expression e -> {
                 // Fallback for Expression (shouldn't happen with new logic)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlFoldingUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlFoldingUtils.java
@@ -64,11 +64,7 @@ public class PromqlFoldingUtils {
         Duration result = switch (op) {
             case ADD -> left.plus(right);
             case SUB -> left.minus(right);
-            default -> throw new ParsingException(
-                source,
-                "Operation [{}] not supported between two durations",
-                op
-            );
+            default -> throw new ParsingException(source, "Operation [{}] not supported between two durations", op);
         };
 
         return result;
@@ -120,11 +116,7 @@ public class PromqlFoldingUtils {
             case ADD -> arithmetics(source, duration, scalar, ArithmeticOp.ADD);
             case SUB -> arithmetics(source, Duration.ofSeconds(scalar.longValue()), duration, ArithmeticOp.SUB);
             case MUL -> arithmetics(source, duration, scalar, ArithmeticOp.MUL);
-            default -> throw new ParsingException(
-                source,
-                "Operation [{}] not supported with scalar on left and duration on right",
-                op
-            );
+            default -> throw new ParsingException(source, "Operation [{}] not supported with scalar on left and duration on right", op);
         };
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlLogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlLogicalPlanBuilder.java
@@ -28,7 +28,6 @@ import org.elasticsearch.xpack.esql.expression.promql.predicate.operator.compari
 import org.elasticsearch.xpack.esql.expression.promql.predicate.operator.comparison.VectorBinaryComparison.ComparisonOp;
 import org.elasticsearch.xpack.esql.expression.promql.predicate.operator.set.VectorBinarySet;
 import org.elasticsearch.xpack.esql.expression.promql.subquery.Subquery;
-import org.elasticsearch.xpack.esql.parser.EsqlBaseParser;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.esql.parser.PromqlBaseParser;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
@@ -296,7 +295,7 @@ public class PromqlLogicalPlanBuilder extends PromqlExpressionBuilder {
             Object leftValue = leftLiteral.value();
             Object rightValue = rightLiteral.value();
 
-            //  arithmetics
+            // arithmetics
             if (binaryOperator instanceof ArithmeticOp arithmeticOp) {
                 Object result = PromqlFoldingUtils.evaluate(source, leftValue, rightValue, arithmeticOp);
                 DataType resultType = determineResultType(result);
@@ -356,19 +355,11 @@ public class PromqlLogicalPlanBuilder extends PromqlExpressionBuilder {
 
         return switch (binaryOperator) {
             case ArithmeticOp arithmeticOp -> new VectorBinaryArithmetic(source, le, re, modifier, arithmeticOp);
-            case ComparisonOp comparisonOp -> new VectorBinaryComparison(
-                source,
-                le,
-                re,
-                modifier,
-                bool,
-                comparisonOp
-            );
+            case ComparisonOp comparisonOp -> new VectorBinaryComparison(source, le, re, modifier, bool, comparisonOp);
             case VectorBinarySet.SetOp setOp -> new VectorBinarySet(source, le, re, modifier, setOp);
             default -> throw new ParsingException(source(ctx.op), "Unknown arithmetic {}", opText);
         };
     }
-
 
     private BinaryOp binaryOp(Token opType) {
         return switch (opType.getType()) {
@@ -548,8 +539,7 @@ public class PromqlLogicalPlanBuilder extends PromqlExpressionBuilder {
                 return duration;
             }
 
-            throw new ParsingException(source(ctx), "Expected duration result, got [{}]",
-                result.getClass().getSimpleName());
+            throw new ParsingException(source(ctx), "Expected duration result, got [{}]", result.getClass().getSimpleName());
         }
 
         // Just COLON with no resolution - use default

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlParams.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlParams.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical.promql;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Container for PromQL command parameters:
+ * <ul>
+ *     <li>time for instant queries</li>
+ *     <li>start, end, step for range queries</li>
+ * </ul>
+ * These can be specified in the {@linkplain org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand PROMQL command} like so:
+ * <pre>
+ *     # instant query
+ *     PROMQL time `2025-10-31T00:00:00Z` (avg(foo))
+ *     # range query with explicit start and end
+ *     PROMQL start `2025-10-31T00:00:00Z` end `2025-10-31T01:00:00Z` step 1m (avg(foo))
+ *     # range query with implicit time bounds, doesn't support calling {@code start()} or {@code end()} functions
+ *     PROMQL step 5m (avg(foo))
+ * </pre>
+ *
+ * @see <a href="https://prometheus.io/docs/prometheus/latest/querying/api/#expression-queries">PromQL API documentation</a>
+ */
+public record PromqlParams(Instant time, Instant start, Instant end, Duration step) {
+
+    public boolean isInstantQuery() {
+        return time != null;
+    }
+
+    public boolean isRangeQuery() {
+        return step != null;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/selector/Selector.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/selector/Selector.java
@@ -18,7 +18,6 @@ import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
 import org.elasticsearch.xpack.esql.plan.logical.promql.PlaceholderRelation;
 
 import java.io.IOException;
-import java.sql.Time;
 import java.util.List;
 import java.util.Objects;
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
@@ -28,9 +28,7 @@ public class PromqlVerifierTests extends ESTestCase {
                 TS test | PROMQL step 5m (
                   rate(network.bytes_in[5m])
                 )""", tsdb),
-            equalTo(
-                "2:3: only aggregations across timeseries are supported at this time (found [rate(network.bytes_in[5m])])"
-            )
+            equalTo("2:3: only aggregations across timeseries are supported at this time (found [rate(network.bytes_in[5m])])")
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlLogicalPlanOptimizerTests.java
@@ -13,8 +13,8 @@ import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
 import org.elasticsearch.xpack.esql.analysis.AnalyzerContext;
-import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RegexMatch;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
@@ -280,26 +280,26 @@ public class PromqlLogicalPlanOptimizerTests extends AbstractLogicalPlanOptimize
         System.out.println(plan);
     }
 
-//    public void testPromqlArithmetricOperators() {
-//        // TODO doesn't parse
-//        //  line 1:27: Invalid query '1+1'[ArithmeticBinaryContext] given; expected LogicalPlan but found VectorBinaryArithmetic
-//        assertThat(
-//            error("TS test | PROMQL step 5m (1+1)", tsdb),
-//            equalTo("1:1: arithmetic operators are not supported at this time [foo]")
-//        );
-//        assertThat(
-//            error("TS test | PROMQL step 5m ( foo and bar )", tsdb),
-//            equalTo("1:1: arithmetic operators are not supported at this time [foo]")
-//        );
-//        assertThat(
-//            error("TS test | PROMQL step 5m (1+foo)", tsdb),
-//            equalTo("1:1: arithmetic operators are not supported at this time [foo]")
-//        );
-//        assertThat(
-//            error("TS test | PROMQL step 5m (foo+bar)", tsdb),
-//            equalTo("1:1: arithmetic operators are not supported at this time [foo]")
-//        );
-//    }
+    // public void testPromqlArithmetricOperators() {
+    // // TODO doesn't parse
+    // // line 1:27: Invalid query '1+1'[ArithmeticBinaryContext] given; expected LogicalPlan but found VectorBinaryArithmetic
+    // assertThat(
+    // error("TS test | PROMQL step 5m (1+1)", tsdb),
+    // equalTo("1:1: arithmetic operators are not supported at this time [foo]")
+    // );
+    // assertThat(
+    // error("TS test | PROMQL step 5m ( foo and bar )", tsdb),
+    // equalTo("1:1: arithmetic operators are not supported at this time [foo]")
+    // );
+    // assertThat(
+    // error("TS test | PROMQL step 5m (1+foo)", tsdb),
+    // equalTo("1:1: arithmetic operators are not supported at this time [foo]")
+    // );
+    // assertThat(
+    // error("TS test | PROMQL step 5m (foo+bar)", tsdb),
+    // equalTo("1:1: arithmetic operators are not supported at this time [foo]")
+    // );
+    // }
 
     protected LogicalPlan planPromql(String query) {
         var analyzed = tsAnalyzer.analyze(parser.createStatement(query));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/promql/PromqlAstTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/promql/PromqlAstTests.java
@@ -7,12 +7,10 @@
 
 package org.elasticsearch.xpack.esql.parser.promql;
 
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.core.QlClientException;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
@@ -32,7 +30,7 @@ import static org.hamcrest.Matchers.not;
  * Test for checking the overall grammar by throwing a number of valid queries at the parser to see whether any exception is raised.
  * In time, the queries themselves get to be checked against the actual execution model and eventually against the expected results.
  */
-//@TestLogging(reason = "debug", value = "org.elasticsearch.xpack.esql.parser.promql:TRACE")
+// @TestLogging(reason = "debug", value = "org.elasticsearch.xpack.esql.parser.promql:TRACE")
 public class PromqlAstTests extends ESTestCase {
 
     private static final Logger log = LogManager.getLogger(PromqlAstTests.class);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/promql/PromqlParamsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/promql/PromqlParamsTests.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.parser.promql;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.parser.EsqlParser;
+import org.elasticsearch.xpack.esql.parser.ParsingException;
+import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.withDefaultLimitWarning;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class PromqlParamsTests extends ESTestCase {
+
+    private static final EsqlParser parser = new EsqlParser();
+
+    public void testValidRangeQuery() {
+        PromqlCommand promql = parse("TS test | PROMQL start `2025-10-31T00:00:00Z` end `2025-10-31T01:00:00Z` step 1m (avg(foo))");
+        assertThat(promql.start(), equalTo(Instant.parse("2025-10-31T00:00:00Z")));
+        assertThat(promql.end(), equalTo(Instant.parse("2025-10-31T01:00:00Z")));
+        assertThat(promql.step(), equalTo(Duration.ofMinutes(1)));
+        assertThat(promql.isRangeQuery(), equalTo(true));
+        assertThat(promql.isInstantQuery(), equalTo(false));
+    }
+
+    public void testValidRangeQueryOnlyStep() {
+        PromqlCommand promql = parse("TS test | PROMQL step 1 (avg(foo))");
+        assertThat(promql.start(), nullValue());
+        assertThat(promql.end(), nullValue());
+        assertThat(promql.step(), equalTo(Duration.ofSeconds(1)));
+        assertThat(promql.isRangeQuery(), equalTo(true));
+        assertThat(promql.isInstantQuery(), equalTo(false));
+    }
+
+    public void testValidInstantQuery() {
+        PromqlCommand promql = parse("TS test | PROMQL time `2025-10-31T00:00:00Z` (avg(foo))");
+        assertThat(promql.start(), nullValue());
+        assertThat(promql.end(), nullValue());
+        assertThat(promql.time(), equalTo(Instant.parse("2025-10-31T00:00:00Z")));
+        assertThat(promql.step(), nullValue());
+        assertThat(promql.isInstantQuery(), equalTo(true));
+        assertThat(promql.isRangeQuery(), equalTo(false));
+    }
+
+    // TODO nicer error messages for missing params
+    public void testMissingParams() {
+        assertThrows(ParsingException.class, () -> parse("TS test | PROMQL (avg(foo))"));
+    }
+
+    public void testZeroStep() {
+        ParsingException e = assertThrows(ParsingException.class, () -> parse("TS test | PROMQL step 0 (avg(foo))"));
+        assertThat(
+            e.getMessage(),
+            containsString(
+                "1:11: invalid parameter \"step\": zero or negative query resolution step widths are not accepted. "
+                    + "Try a positive integer"
+            )
+        );
+    }
+
+    public void testNegativeStep() {
+        ParsingException e = assertThrows(ParsingException.class, () -> parse("TS test | PROMQL step `-1` (avg(foo))"));
+        assertThat(
+            e.getMessage(),
+            containsString("invalid parameter \"step\": zero or negative query resolution step widths are not accepted")
+        );
+    }
+
+    public void testEndBeforeStart() {
+        ParsingException e = assertThrows(
+            ParsingException.class,
+            () -> parse("TS test | PROMQL start `2025-10-31T01:00:00Z` end `2025-10-31T00:00:00Z` step 1m (avg(foo))")
+        );
+        assertThat(e.getMessage(), containsString("1:11: invalid parameter \"end\": end timestamp must not be before start time"));
+    }
+
+    public void testInstantAndRangeParams() {
+        ParsingException e = assertThrows(
+            ParsingException.class,
+            () -> parse(
+                "TS test | PROMQL start `2025-10-31T00:00:00Z` end `2025-10-31T01:00:00Z` step 1m time `2025-10-31T00:00:00Z` (avg(foo))"
+            )
+        );
+        assertThat(
+            e.getMessage(),
+            containsString("1:11: Specify either [time] for instant query or [step}], [start] or [end}] for a range query")
+        );
+    }
+
+    public void testDuplicateParameter() {
+        ParsingException e = assertThrows(ParsingException.class, () -> parse("TS test | PROMQL step 1 step 2 (avg(foo))"));
+        assertThat(e.getMessage(), containsString("[step] already specified"));
+    }
+
+    public void testUnknownParameter() {
+        ParsingException e = assertThrows(ParsingException.class, () -> parse("TS test | PROMQL stp 1 (avg(foo))"));
+        assertThat(e.getMessage(), containsString("Unknown parameter [stp], did you mean [step]?"));
+    }
+
+    public void testUnknownParameterNoSuggestion() {
+        ParsingException e = assertThrows(ParsingException.class, () -> parse("TS test | PROMQL foo 1 (avg(foo))"));
+        assertThat(e.getMessage(), containsString("Unknown parameter [foo]"));
+    }
+
+    public void testInvalidDateFormat() {
+        ParsingException e = assertThrows(
+            ParsingException.class,
+            () -> parse("TS test | PROMQL start `not-a-date` end `2025-10-31T01:00:00Z` step 1m (avg(foo))")
+        );
+        assertThat(e.getMessage(), containsString("1:24: Invalid date format [not-a-date]"));
+    }
+
+    public void testOnlyStartSpecified() {
+        ParsingException e = assertThrows(
+            ParsingException.class,
+            () -> parse("TS test | PROMQL start `2025-10-31T00:00:00Z` step 1m (avg(foo))")
+        );
+        assertThat(
+            e.getMessage(),
+            containsString("Parameters [start] and [end] must either both be specified or both be omitted for a range query")
+        );
+    }
+
+    public void testOnlyEndSpecified() {
+        ParsingException e = assertThrows(
+            ParsingException.class,
+            () -> parse("TS test | PROMQL end `2025-10-31T01:00:00Z` step 1m (avg(foo))")
+        );
+        assertThat(
+            e.getMessage(),
+            containsString("Parameters [start] and [end] must either both be specified or both be omitted for a range query")
+        );
+    }
+
+    public void testRangeQueryMissingStep() {
+        ParsingException e = assertThrows(
+            ParsingException.class,
+            () -> parse("TS test | PROMQL start `2025-10-31T00:00:00Z` end `2025-10-31T01:00:00Z` (avg(foo))")
+        );
+        assertThat(e.getMessage(), containsString("Parameter [step] or [time] is required"));
+    }
+
+    private static PromqlCommand parse(String query) {
+        return as(parser.createStatement(query), PromqlCommand.class);
+    }
+
+    @Override
+    protected List<String> filteredWarnings() {
+        return withDefaultLimitWarning(super.filteredWarnings());
+    }
+
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/promql/PromqlParserUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/promql/PromqlParserUtilsTests.java
@@ -24,7 +24,7 @@ import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.containsString;
 
-public class ParsingUtilTests extends ESTestCase {
+public class PromqlParserUtilsTests extends ESTestCase {
 
     private Duration parseTimeValue(String value) {
         return PromqlParserUtils.parseDuration(new Source(0, 0, value), value);
@@ -53,24 +53,14 @@ public class ParsingUtilTests extends ESTestCase {
         assertEquals(ofDays(365).plus(ofSeconds(6)), parseTimeValue("1y6s"));
         assertEquals(ofDays(365).plus(ofMillis(7)), parseTimeValue("1y7ms"));
 
-        assertEquals(
-            ofDays(365).plus(ofDays(14)).plus(ofDays(3)),
-            parseTimeValue("1y2w3d")
-        );
+        assertEquals(ofDays(365).plus(ofDays(14)).plus(ofDays(3)), parseTimeValue("1y2w3d"));
+
+        assertEquals(ofDays(365).plus(ofDays(3)).plus(ofHours(4)), parseTimeValue("1y3d4h"));
+
+        assertEquals(ofDays(365).plus(ofMinutes(5)).plus(ofSeconds(6)), parseTimeValue("1y5m6s"));
 
         assertEquals(
-            ofDays(365).plus(ofDays(3)).plus(ofHours(4)),
-            parseTimeValue("1y3d4h")
-        );
-
-        assertEquals(
-            ofDays(365).plus(ofMinutes(5)).plus(ofSeconds(6)),
-            parseTimeValue("1y5m6s")
-        );
-
-        assertEquals(
-            ofDays(365).plus(ofDays(7)).plus(ofDays(1)).plus(ofHours(1))
-                .plus(ofMinutes(1)).plus(ofSeconds(1)).plus(ofMillis(1)),
+            ofDays(365).plus(ofDays(7)).plus(ofDays(1)).plus(ofHours(1)).plus(ofMinutes(1)).plus(ofSeconds(1)).plus(ofMillis(1)),
             parseTimeValue("1y1w1d1h1m1s1ms")
         );
 


### PR DESCRIPTION
Only parses the parameters, doesn't actually do anything with them, yet.

I'm hoping we can make start/end optional and a consequence of not specifying is that the `start()` and `end()` functions return an error.

This seems like a sensible pattern when used within Kibana, for example when creating an ES|QL-based visualization. Kibana is already supplying a filter for the time range outside of the query itself, so having to specify start/end would be redundant. The start/end parameters can still be used within and outside of Kibana but will likely mostly be useful outside of Kibana, and act similar to `TRANGE`.

We'll need to solve the issue of increasing the time window we load data from. But I see this as a separate issue that we should solve when tackling window functions. This includes handling the complexity of mixing start/end, time filtering using `filter` (as Kibana does), and TBUCKET/WHERE filtering in the same query. 

Examples:

```
# instant query
PROMQL time `2025-10-31T00:00:00Z` (avg(foo))
# range query with explicit start and end
PROMQL start `2025-10-31T00:00:00Z` end `2025-10-31T01:00:00Z` step 1m (avg(foo))
# range query with implicit time bounds
# doesn't support calling start() or end() functions
PROMQL step 5m (avg(foo))
 ```