### PR TITLE
Mirror upstream elastic/elasticsearch#137530 for AI review (snapshot of HEAD tree)

### DIFF
--- a/docs/changelog/137530.yaml
+++ b/docs/changelog/137530.yaml
@@ -1,0 +1,5 @@
+pr: 137530
+summary: Allows field caps to be cross project
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
@@ -14,11 +14,13 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.LegacyActionRequest;
+import org.elasticsearch.action.ResolvedIndexExpressions;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
@@ -51,6 +53,8 @@ public final class FieldCapabilitiesRequest extends LegacyActionRequest implemen
     private String[] types = Strings.EMPTY_ARRAY;
     private boolean includeUnmapped = false;
     private boolean includeEmptyFields = true;
+    @Nullable
+    private ResolvedIndexExpressions resolvedIndexExpressions = null;
     /**
      * Controls whether the field caps response should always include the list of indices
      * where a field is defined. This flag is only used locally on the coordinating node,
@@ -60,6 +64,7 @@ public final class FieldCapabilitiesRequest extends LegacyActionRequest implemen
     private transient boolean includeIndices = false;
 
     private boolean includeResolvedTo = false;
+    private String projectRouting;
 
     /**
      * Controls whether all local indices should be returned if no remotes matched
@@ -257,6 +262,31 @@ public final class FieldCapabilitiesRequest extends LegacyActionRequest implemen
     @Override
     public boolean allowsRemoteIndices() {
         return true;
+    }
+
+    @Override
+    public boolean allowsCrossProject() {
+        return true;
+    }
+
+    @Override
+    public void setResolvedIndexExpressions(ResolvedIndexExpressions expressions) {
+        this.resolvedIndexExpressions = expressions;
+    }
+
+    @Override
+    @Nullable
+    public ResolvedIndexExpressions getResolvedIndexExpressions() {
+        return resolvedIndexExpressions;
+    }
+
+    public void projectRouting(String projectRouting) {
+        this.projectRouting = projectRouting;
+    }
+
+    @Override
+    public String getProjectRouting() {
+        return projectRouting;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -321,6 +321,11 @@ public class FieldCapabilitiesResponse extends ActionResponse implements Chunked
             return this;
         }
 
+        public Builder withResolvedRemotely(Map<String, ResolvedIndexExpressions> resolvedRemotely) {
+            this.resolvedRemotely = resolvedRemotely;
+            return this;
+        }
+
         public Builder withResolvedLocally(ResolvedIndexExpressions resolvedLocally) {
             this.resolvedLocally = resolvedLocally;
             return this;

--- a/server/src/main/java/org/elasticsearch/rest/action/RestFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestFieldCapabilitiesAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
+import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 
@@ -33,9 +34,11 @@ import static org.elasticsearch.xcontent.ObjectParser.fromList;
 public class RestFieldCapabilitiesAction extends BaseRestHandler {
 
     private final Settings settings;
+    private final CrossProjectModeDecider crossProjectModeDecider;
 
     public RestFieldCapabilitiesAction(Settings settings) {
         this.settings = settings;
+        this.crossProjectModeDecider = new CrossProjectModeDecider(settings);
     }
 
     @Override
@@ -55,14 +58,25 @@ public class RestFieldCapabilitiesAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        if (settings != null && settings.getAsBoolean("serverless.cross_project.enabled", false)) {
-            // accept but drop project_routing param until fully supported
-            request.param("project_routing");
+        final FieldCapabilitiesRequest fieldRequest = new FieldCapabilitiesRequest();
+
+        final boolean crossProjectEnabled = crossProjectModeDecider.crossProjectEnabled();
+        if (crossProjectModeDecider.crossProjectEnabled()) {
+            fieldRequest.projectRouting(request.param("project_routing", null));
+            // Setting includeResolvedTo to always include index resolution data structure in the linked project responses,
+            // in order to allow the coordinating node to call CrossProjectIndexResolutionValidator#validate
+            fieldRequest.includeResolvedTo(true);
         }
 
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
-        final FieldCapabilitiesRequest fieldRequest = new FieldCapabilitiesRequest();
         fieldRequest.indices(indices);
+
+        if (crossProjectEnabled && fieldRequest.allowsCrossProject()) {
+            var cpsIdxOpts = IndicesOptions.builder(fieldRequest.indicesOptions())
+                .crossProjectModeOptions(new IndicesOptions.CrossProjectModeOptions(true))
+                .build();
+            fieldRequest.indicesOptions(cpsIdxOpts);
+        }
 
         fieldRequest.indicesOptions(IndicesOptions.fromRequest(request, fieldRequest.indicesOptions()));
         fieldRequest.includeUnmapped(request.paramAsBoolean("include_unmapped", false));


### PR DESCRIPTION
Enables Field Capabilities endpoint to be cross project. (allowsCrossProject return true)
Disable cross project chaining (by calling indicesOptionsForCrossProjectFanout that sets CrossProjectModeOptions back to default)
Adds project routing parameter if crossProjectEnabled