### PR TITLE
Mirror upstream elastic/elasticsearch#137203 for AI review (snapshot of HEAD tree)

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractBaseReindexRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractBaseReindexRestHandler.java
@@ -44,6 +44,10 @@ public abstract class AbstractBaseReindexRestHandler<
         // Build the internal request
         Request internal = setCommonOptions(request, buildRequest(request));
 
+        // Only requests supporting remote indices can have IndicesOptions allowing cross-project index expressions
+        assert internal.supportsRemoteIndicesSearch()
+            || internal.getSearchRequest().indicesOptions().resolveCrossProjectIndexExpression() == false;
+
         // Executes the request and waits for completion
         if (request.paramAsBoolean("wait_for_completion", true)) {
             Map<String, String> params = new HashMap<>();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -479,12 +479,7 @@ public class IndexNameExpressionResolver {
             return;
         }
         if (RemoteClusterAware.isRemoteIndexName(current)) {
-            List<String> crossClusterIndices = new ArrayList<>();
-            for (int i = 0; i < expressions.length; i++) {
-                if (RemoteClusterAware.isRemoteIndexName(expressions[i])) {
-                    crossClusterIndices.add(expressions[i]);
-                }
-            }
+            List<String> crossClusterIndices = RemoteClusterAware.getRemoteIndexExpressions(expressions);
             throw new IllegalArgumentException(
                 "Cross-cluster calls are not supported in this context but remote indices were requested: " + crossClusterIndices
             );

--- a/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -137,6 +137,13 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
      */
     protected abstract Self self();
 
+    /**
+     * Whether the request supports remote indices in the search request.
+     */
+    public boolean supportsRemoteIndicesSearch() {
+        return false;
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException e = searchRequest.validate();

--- a/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
@@ -84,6 +84,11 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
     }
 
     @Override
+    public boolean supportsRemoteIndicesSearch() {
+        return true;
+    }
+
+    @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException e = super.validate();
         if (getSearchRequest().indices() == null || getSearchRequest().indices().length == 0) {

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
@@ -70,6 +70,19 @@ public abstract class RemoteClusterAware implements LinkedProjectConfigService.L
     }
 
     /**
+     * Extracts the list of remote index expressions from the given array of index expressions
+     */
+    public static List<String> getRemoteIndexExpressions(String... expressions) {
+        List<String> crossClusterIndices = new ArrayList<>();
+        for (int i = 0; i < expressions.length; i++) {
+            if (isRemoteIndexName(expressions[i])) {
+                crossClusterIndices.add(expressions[i]);
+            }
+        }
+        return crossClusterIndices;
+    }
+
+    /**
      * @param indexExpression expects a single index expression at a time (not a csv list of expression)
      * @return cluster alias in the index expression. If none is present, returns RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY
      */

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterAwareTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterAwareTests.java
@@ -16,10 +16,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 
 public class RemoteClusterAwareTests extends ESTestCase {
@@ -156,6 +159,23 @@ public class RemoteClusterAwareTests extends ESTestCase {
             "The '-' exclusions in the index expression list excludes all indexes"
         );
 
+    }
+
+    public void testGetRemoteIndexExpressions() {
+        {
+            List<String> remoteIndexExpressions = RemoteClusterAware.getRemoteIndexExpressions("index-1");
+            assertThat(remoteIndexExpressions, empty());
+        }
+        {
+            List<String> remoteIndexExpressions = RemoteClusterAware.getRemoteIndexExpressions(
+                "index-1",
+                "remote:index-1",
+                "idx-*",
+                "remote-2:idx-5"
+            );
+            assertThat(remoteIndexExpressions, hasSize(2));
+            assertThat(remoteIndexExpressions, contains("remote:index-1", "remote-2:idx-5"));
+        }
     }
 
     private static class RemoteClusterAwareTest extends RemoteClusterAware {


### PR DESCRIPTION
This PR introduces an assertion to make sure that delete-by-query/update-by-query can't have indices options enabling flat-world, and also extracts the method to find cross-project/cross-cluster index expressions from a list of index expressions that is used in `ActionFilter`s to disable cross-project requests in Serverless.

This change doesn't prohibit cross-cluster update-by-query/delete-by-query requests even though these requests were never supposed to work in CCS, since doing so could lead to a breaking change: https://github.com/elastic/dev/issues/3350

 [ES-12969]

[ES-12969]: https://elasticco.atlassian.net/browse/ES-12969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ