### PR TITLE
Mirror upstream elastic/elasticsearch#137511 for AI review (snapshot of HEAD tree)

### DIFF
--- a/docs/changelog/137511.yaml
+++ b/docs/changelog/137511.yaml
@@ -1,0 +1,5 @@
+pr: 137511
+summary: Fixes esql class cast bug in STATS at planning level
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -3463,3 +3463,89 @@ employees:long | job_positions:keyword
 15             | Tech Lead    
 ;
 
+fixClassCastBugWithCountDistinct
+required_capability: fix_stats_classcast_exception
+
+from airports 
+| rename scalerank AS x 
+| stats  a = count(x), b = count(x) + count(x), c = count_distinct(x)
+;
+
+a:long | b:long | c:long
+891    | 1782   | 8
+;
+
+fixClassCastBugWithValuesFn
+required_capability: fix_stats_classcast_exception
+
+ROW x = [1,2,3] 
+| STATS a = MV_COUNT(VALUES(x)), b = VALUES(x), c = SUM(x)
+;
+
+a:integer | b:integer | c:long
+3         | [1, 2, 3] | 6
+;
+
+fixClassCastBugWithSeveralCountDistincts
+required_capability: fix_stats_classcast_exception
+
+ROW x = 1 
+| STATS a = 2*COUNT_DISTINCT(x), b = COUNT_DISTINCT(x), c = MAX(x)
+;
+
+a:long | b:long | c:integer
+2      | 1      | 1
+;
+
+fixClassCastBugWithSeveralCounts
+required_capability: inline_stats
+required_capability: fix_stats_classcast_exception
+
+FROM sample_data, sample_data_str
+| EVAL one_ip = client_ip::ip
+| INLINE STATS count1=count(client_ip::ip), count2=count(one_ip)
+| KEEP count1, count2
+| LIMIT 3
+;
+
+count1:long    |count2:long
+14             |14 
+14             |14 
+14             |14
+;
+
+fixClassCastBugWithMedianPlusCountDistinct
+required_capability: fix_stats_classcast_exception
+
+FROM sample_data_ts_long 
+| EVAL sym1 = 0, sym5 = 1
+| STATS sym2 = median(sym5) + 0, sym3 = median(sym5), sym4 = count_distinct(sym1)
+;
+
+sym2:double |sym3:double | sym4:long
+1.0         | 1.0        | 1
+;
+
+fixClassCastBug6
+required_capability: fix_stats_classcast_exception
+
+from airports 
+| rename scalerank AS x 
+| stats  a = count(x), b = count(x) + count(x), c = count_distinct(x, 10), d = count_distinct(x, 10 + 1 - 1)
+;
+
+a:long | b:long | c:long | d:long
+891    | 1782   | 8      | 8
+;
+
+fixClassCastBugWithSurrogateExpressions
+required_capability: fix_stats_classcast_exception
+
+from airports 
+| rename scalerank AS x 
+| stats a = median(x), b = percentile(x, 50), c = count_distinct(x)
+;
+
+a:double | b:double | c:long
+6.0      | 6.0      | 8
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1580,6 +1580,13 @@ public class EsqlCapabilities {
         PUSHING_DOWN_EVAL_WITH_SCORE,
 
         /**
+         * Fix for ClassCastException in STATS
+         * https://github.com/elastic/elasticsearch/issues/133992
+         * https://github.com/elastic/elasticsearch/issues/136598
+         */
+        FIX_STATS_CLASSCAST_EXCEPTION,
+
+        /**
          * Fix attribute equality to respect the name id of the attribute.
          */
         ATTRIBUTE_EQUALS_RESPECTS_NAME_ID,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.logical.CombineEvals;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.CombineLimitTopN;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.CombineProjections;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ConstantFolding;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.DeduplicateAggs;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ExtractAggregateCommonFilter;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.FoldNull;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.HoistRemoteEnrichLimit;
@@ -178,6 +179,8 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
             new SplitInWithFoldableValue(),
             new PropagateEvalFoldables(),
             new ConstantFolding(),
+            // then extract nested aggs top-level
+            new DeduplicateAggs(),
             new PartiallyFoldCase(),
             // boolean
             new BooleanSimplification(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/DeduplicateAggs.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/DeduplicateAggs.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
-import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
@@ -18,33 +17,21 @@ import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.grouping.GroupingFunction;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
-import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Replace nested expressions over aggregates with synthetic eval post the aggregation
- * stats a = sum(a) + min(b) by x
- * becomes
- * stats a1 = sum(a), a2 = min(b) by x | eval a = a1 + a2 | keep a, x
- * The rule also considers expressions applied over groups:
- * {@code STATS a = x + 1 BY x} becomes {@code STATS BY x | EVAL a = x + 1 | KEEP a, x}
- * And to combine the two:
- * stats a = x + count(*) by x
- * becomes
- * stats a1 = count(*) by x | eval a = x + a1 | keep a1, x
- * Since the logic is very similar, this rule also handles duplicate aggregate functions to avoid duplicate compute
+ * This rule handles duplicate aggregate functions to avoid duplicate compute
  * stats a = min(x), b = min(x), c = count(*), d = count() by g
  * becomes
  * stats a = min(x), c = count(*) by g | eval b = a, d = c | keep a, b, c, d, g
  */
-public final class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.OptimizerRule<Aggregate> {
-    public ReplaceAggregateAggExpressionWithEval() {
+public final class DeduplicateAggs extends OptimizerRules.OptimizerRule<Aggregate> implements OptimizerRules.CoordinatorOnly {
+    public DeduplicateAggs() {
         super(OptimizerRules.TransformDirection.UP);
     }
 
@@ -52,14 +39,8 @@ public final class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.
     protected LogicalPlan rule(Aggregate aggregate) {
         // an alias map for evaluatable grouping functions
         AttributeMap.Builder<Expression> aliasesBuilder = AttributeMap.builder();
-        // a function map for non-evaluatable grouping functions
-        Map<GroupingFunction.NonEvaluatableGroupingFunction, Attribute> nonEvalGroupingAttributes = new HashMap<>(
-            aggregate.groupings().size()
-        );
         aggregate.forEachExpressionUp(Alias.class, a -> {
-            if (a.child() instanceof GroupingFunction.NonEvaluatableGroupingFunction groupingFunction) {
-                nonEvalGroupingAttributes.put(groupingFunction, a.toAttribute());
-            } else {
+            if (a.child() instanceof GroupingFunction.NonEvaluatableGroupingFunction == false) {
                 aliasesBuilder.put(a.toAttribute(), a.child());
             }
         });
@@ -71,14 +52,11 @@ public final class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.
 
         // root/naked aggs
         Map<AggregateFunction, Alias> rootAggs = Maps.newLinkedHashMapWithExpectedSize(aggs.size());
-        // evals (original expression relying on multiple aggs)
-        List<Alias> newEvals = new ArrayList<>();
         List<NamedExpression> newProjections = new ArrayList<>();
         // track the aggregate aggs (including grouping which is not an AggregateFunction)
         List<NamedExpression> newAggs = new ArrayList<>();
 
         Holder<Boolean> changed = new Holder<>(false);
-        int[] counter = new int[] { 0 };
 
         for (NamedExpression agg : aggs) {
             if (agg instanceof Alias as) {
@@ -88,7 +66,7 @@ public final class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.
                 // common case - handle duplicates
                 if (child instanceof AggregateFunction af) {
                     // canonical representation, with resolved aliases
-                    AggregateFunction canonical = (AggregateFunction) af.canonical().transformUp(e -> aliases.resolve(e, e));
+                    AggregateFunction canonical = (AggregateFunction) af.transformUp(e -> aliases.resolve(e, e));
 
                     Alias found = rootAggs.get(canonical);
                     // aggregate is new
@@ -104,36 +82,6 @@ public final class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.
                         newProjections.add(as.replaceChild(found.toAttribute()));
                     }
                 }
-                // nested expression over aggregate function or groups
-                // replace them with reference and move the expression into a follow-up eval
-                else {
-                    changed.set(true);
-                    Expression aggExpression = child.transformUp(AggregateFunction.class, af -> {
-                        // canonical representation, with resolved aliases
-                        AggregateFunction canonical = (AggregateFunction) af.canonical().transformUp(e -> aliases.resolve(e, e));
-                        Alias alias = rootAggs.get(canonical);
-                        if (alias == null) {
-                            // create synthetic alias over the found agg function
-                            alias = new Alias(af.source(), syntheticName(canonical, child, counter[0]++), af.canonical(), null, true);
-                            // and remember it to remove duplicates
-                            rootAggs.put(canonical, alias);
-                            // add it to the list of aggregates and continue
-                            newAggs.add(alias);
-                        }
-                        // (even when found) return a reference to it
-                        return alias.toAttribute();
-                    });
-
-                    // replace non-evaluatable grouping functions with their references
-                    aggExpression = aggExpression.transformUp(
-                        GroupingFunction.NonEvaluatableGroupingFunction.class,
-                        nonEvalGroupingAttributes::get
-                    );
-
-                    Alias alias = as.replaceChild(aggExpression);
-                    newEvals.add(alias);
-                    newProjections.add(alias.toAttribute());
-                }
             }
             // not an alias (e.g. grouping field)
             else {
@@ -146,17 +94,10 @@ public final class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.
         if (changed.get()) {
             Source source = aggregate.source();
             plan = aggregate.with(aggregate.child(), aggregate.groupings(), newAggs);
-            if (newEvals.size() > 0) {
-                plan = new Eval(source, plan, newEvals);
-            }
             // preserve initial projection
             plan = new Project(source, plan, newProjections);
         }
 
         return plan;
-    }
-
-    private static String syntheticName(Expression expression, Expression af, int counter) {
-        return TemporaryNameUtils.temporaryName(expression, af, counter);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -535,30 +535,6 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
 
     /**
      * <pre>{@code
-     * Project[[s{r}#4 AS d, s{r}#4, last_name{f}#21, first_name{f}#18]]
-     * \_Limit[1000[INTEGER]]
-     *   \_Aggregate[[last_name{f}#21, first_name{f}#18],[SUM(salary{f}#22) AS s, last_name{f}#21, first_name{f}#18]]
-     *     \_EsRelation[test][_meta_field{f}#23, emp_no{f}#17, first_name{f}#18, ..]
-     * }</pre>
-     */
-    public void testCombineProjectionWithDuplicateAggregation() {
-        var plan = plan("""
-            from test
-            | stats s = sum(salary), d = sum(salary), c = sum(salary) by last_name, first_name
-            | keep d, s, last_name, first_name
-            """);
-
-        var project = as(plan, Project.class);
-        assertThat(Expressions.names(project.projections()), contains("d", "s", "last_name", "first_name"));
-        var limit = as(project.child(), Limit.class);
-        var agg = as(limit.child(), Aggregate.class);
-        assertThat(Expressions.names(agg.aggregates()), contains("s", "last_name", "first_name"));
-        assertThat(Alias.unwrap(agg.aggregates().get(0)), instanceOf(Sum.class));
-        assertThat(Expressions.names(agg.groupings()), contains("last_name", "first_name"));
-    }
-
-    /**
-     * <pre>{@code
      * Limit[1000[INTEGER]]
      * \_Aggregate[STANDARD,[],[SUM(salary{f}#12,true[BOOLEAN]) AS sum(salary), SUM(salary{f}#12,last_name{f}#11 == [44 6f 65][KEYW
      * ORD]) AS sum(salary) WheRe last_name ==   "Doe"]]

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/DeduplicateAggsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/DeduplicateAggsTests.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical;
+
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.CountDistinct;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Mul;
+import org.elasticsearch.xpack.esql.optimizer.AbstractLogicalPlanOptimizerTests;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+
+//@TestLogging(value = "org.elasticsearch.xpack.esql:TRACE", reason = "debug")
+public class DeduplicateAggsTests extends AbstractLogicalPlanOptimizerTests {
+    /**
+     * <pre>{@code
+     * Project[[s{r}#4 AS d, s{r}#4, last_name{f}#21, first_name{f}#18]]
+     * \_Limit[1000[INTEGER]]
+     *   \_Aggregate[[last_name{f}#21, first_name{f}#18],[SUM(salary{f}#22) AS s, last_name{f}#21, first_name{f}#18]]
+     *     \_EsRelation[test][_meta_field{f}#23, emp_no{f}#17, first_name{f}#18, ..]
+     * }</pre>
+     */
+    public void testCombineProjectionWithDuplicateAggregation() {
+        var plan = plan("""
+            from test
+            | stats s = sum(salary), d = sum(salary), c = sum(salary) by last_name, first_name
+            | keep d, s, last_name, first_name
+            """);
+
+        var project = as(plan, Project.class);
+        assertThat(Expressions.names(project.projections()), contains("d", "s", "last_name", "first_name"));
+        var limit = as(project.child(), Limit.class);
+        var agg = as(limit.child(), Aggregate.class);
+        assertThat(Expressions.names(agg.aggregates()), contains("s", "last_name", "first_name"));
+        assertThat(Alias.unwrap(agg.aggregates().get(0)), instanceOf(Sum.class));
+        assertThat(Expressions.names(agg.groupings()), contains("last_name", "first_name"));
+    }
+
+    /**
+     * <pre>{@code
+     * Project[[a{r}#8, b{r}#12, c{r}#15, c{r}#15 AS d#18]]
+     * \_Eval[[a{r}#8 + a{r}#8 AS b#12]]
+     *   \_Limit[1000[INTEGER],false,false]
+     *     \_Aggregate[[],[COUNT(scalerank{f}#21,true[BOOLEAN],PT0S[TIME_DURATION]) AS a#8, COUNTDISTINCT(scalerank{f}#21,true[BOOLEAN],PT0S[TIME_DURATION],10[INTEGER]) AS c#15]]
+     *       \_EsRelation[airports][abbrev{f}#19, city{f}#25, city_location{f}#26, coun..]
+     * }</pre>
+     */
+    public void testAggsDeduplication() {
+        assumeTrue("requires FIX FOR CLASSCAST exception to be enabled", EsqlCapabilities.Cap.FIX_STATS_CLASSCAST_EXCEPTION.isEnabled());
+        String query = """
+                FROM airports
+                | rename scalerank AS x
+                | stats  a = count(x), b = count(x) + count(x), c = count_distinct(x, 10), d = count_distinct(x, 10 + 1 - 1)
+            """;
+
+        LogicalPlan plan = planAirports(query);
+        Project project = as(plan, Project.class);
+        var projections = project.projections();
+        assertThat(projections, hasSize(4));
+        var a = as(projections.get(0), ReferenceAttribute.class);
+        var b = as(projections.get(1), ReferenceAttribute.class);
+        var c = as(projections.get(2), ReferenceAttribute.class);
+        var d = as(projections.get(3), Alias.class);
+
+        assertEquals("a", a.name());
+        assertEquals("b", b.name());
+        assertEquals("c", c.name());
+        assertEquals("d", d.name());
+        assertEquals("c", as(d.child(), ReferenceAttribute.class).name());
+
+        Eval eval = as(project.child(), Eval.class);
+        assertThat(eval.fields(), hasSize(1));
+        var bEval = as(eval.fields().getFirst(), Alias.class);
+        var bAdd = as(bEval.child(), Add.class);
+
+        assertEquals("a", as(bAdd.left(), ReferenceAttribute.class).name());
+        assertEquals("a", as(bAdd.right(), ReferenceAttribute.class).name());
+        assertEquals("b", bEval.name());
+
+        Limit limit = as(eval.child(), Limit.class);
+        Aggregate agg = as(limit.child(), Aggregate.class);
+
+        assertThat(agg.aggregates(), hasSize(2));
+        var countAlias = as(agg.aggregates().get(0), Alias.class);
+        var countDistinctAliasFirst = as(agg.aggregates().get(1), Alias.class);
+
+        var count = as(countAlias.child(), Count.class);
+        var countDistinct = as(countDistinctAliasFirst.child(), CountDistinct.class);
+
+        assertEquals("a", countAlias.name());
+        assertEquals("c", countDistinctAliasFirst.name());
+        assertEquals("scalerank", as(count.field(), FieldAttribute.class).name());
+        assertEquals("scalerank", as(countDistinct.field(), FieldAttribute.class).name());
+    }
+
+    /**
+     * <pre>{@code
+     * Project[[MAX(y){r}#16, 2* MAX(a){r}#18]]
+     * \_Eval[[MAX(y){r}#16 * 2[INTEGER] AS 2* MAX(a)#18]]
+     *   \_Limit[1000[INTEGER],false,false]
+     *     \_Aggregate[[],[MAX(scalerank{f}#21,true[BOOLEAN],PT0S[TIME_DURATION]) AS MAX(y)#16]]
+     *       \_EsRelation[airports][abbrev{f}#19, city{f}#25, city_location{f}#26, coun..]
+     * }</pre>
+     */
+    public void testAggsDeduplicationWithComplicatedAliasChains() {
+        assumeTrue("requires FIX FOR CLASSCAST exception to be enabled", EsqlCapabilities.Cap.FIX_STATS_CLASSCAST_EXCEPTION.isEnabled());
+        String query = """
+                FROM airports
+                | rename scalerank AS x
+                | EVAL y = x, z = x
+                | RENAME z AS a
+                | STATS MAX(y), 2* MAX(a)
+            """;
+
+        LogicalPlan plan = planAirports(query);
+        Project project = as(plan, Project.class);
+        var projections = project.projections();
+        assertThat(projections, hasSize(2));
+
+        var firstResult = as(projections.get(0), ReferenceAttribute.class);
+        var secondResult = as(projections.get(1), ReferenceAttribute.class);
+        assertEquals("MAX(y)", firstResult.name());
+        assertEquals("2* MAX(a)", secondResult.name());
+
+        var eval = as(project.child(), Eval.class);
+        var outputs = eval.output();
+        assertThat(outputs, hasSize(2));
+
+        assertEquals("MAX(y)", as(outputs.get(0), ReferenceAttribute.class).name());
+        assertEquals("2* MAX(a)", as(outputs.get(1), ReferenceAttribute.class).name());
+        assertThat(eval.fields(), hasSize(1));
+        var twoMax = as(eval.fields().getFirst(), Alias.class);
+        var mul = as(twoMax.child(), Mul.class);
+        assertEquals("MAX(y)", as(mul.left(), ReferenceAttribute.class).name());
+        assertEquals(2, as(mul.right(), Literal.class).value());
+        assertEquals("2* MAX(a)", twoMax.name());
+
+        var aggregates = as(as(eval.child(), Limit.class).child(), Aggregate.class).aggregates();
+        assertThat(aggregates, hasSize(1));
+        var agg = as(aggregates.getFirst(), Alias.class);
+        assertEquals("MAX(y)", agg.name());
+        var maxY = as(agg.child(), Max.class);
+        assertEquals("scalerank", as(maxY.field(), FieldAttribute.class).name());
+    }
+
+    /**
+     * <pre>{@code
+     * Project[[COUNT(y){r}#7, 2 * COUNT(scalerank){r}#9, y{r}#5]]
+     * \_Eval[[COUNT(y){r}#7 * 2[INTEGER] AS 2 * COUNT(scalerank)#9]]
+     *   \_Limit[1000[INTEGER],false,false]
+     *     \_Aggregate[[scalerank{f}#13],[COUNT(scalerank{f}#13,true[BOOLEAN],PT0S[TIME_DURATION]) AS COUNT(y)#7, scalerank{f}#13 AS y
+     * #5]]
+     *       \_EsRelation[airports][abbrev{f}#11, city{f}#17, city_location{f}#18, coun..]
+     * }</pre>
+     */
+    public void testAggsDeduplicationInByClauses() {
+        assumeTrue("requires FIX FOR CLASSCAST exception to be enabled", EsqlCapabilities.Cap.FIX_STATS_CLASSCAST_EXCEPTION.isEnabled());
+        String query = """
+                FROM airports
+                | STATS COUNT(y), 2 * COUNT(scalerank) BY y = scalerank
+            """;
+
+        LogicalPlan plan = planAirports(query);
+        Project project = as(plan, Project.class);
+        var projections = project.projections();
+        assertThat(projections, hasSize(3));
+
+        assertEquals("COUNT(y)", as(projections.get(0), ReferenceAttribute.class).name());
+        assertEquals("2 * COUNT(scalerank)", as(projections.get(1), ReferenceAttribute.class).name());
+        assertEquals("y", as(projections.get(2), ReferenceAttribute.class).name());
+
+        var eval = as(project.child(), Eval.class);
+
+        assertThat(eval.fields(), hasSize(1));
+        var evalAlias = as(eval.fields().getFirst(), Alias.class);
+        var mul = as(evalAlias.child(), Mul.class);
+        assertEquals("COUNT(y)", as(mul.left(), ReferenceAttribute.class).name());
+        assertEquals(2, as(mul.right(), Literal.class).value());
+        assertEquals("2 * COUNT(scalerank)", evalAlias.name());
+
+        var aggregates = as(as(eval.child(), Limit.class).child(), Aggregate.class).aggregates();
+        assertThat(aggregates, hasSize(2));
+
+        var countAlias = as(aggregates.getFirst(), Alias.class);
+        assertEquals("COUNT(y)", countAlias.name());
+        var countField = as(countAlias.child(), Count.class).field();
+        assertEquals("scalerank", as(countField, FieldAttribute.class).name());
+        assertEquals("scalerank", as(as(aggregates.get(1), Alias.class).child(), FieldAttribute.class).name());
+    }
+
+    /**
+     * <pre>{@code
+     * Project[[a{r}#5, b{r}#9, c{r}#13]]
+     * \_Eval[[a{r}#5 * 2[INTEGER] AS b#9]]
+     *   \_Limit[1000[INTEGER],false,false]
+     *     \_Aggregate[[],[COUNT(scalerank{f}#16,scalerank{f}#16 > 7[INTEGER],PT0S[TIME_DURATION]) AS a#5, COUNTDISTINCT(scalerank{f}#
+     * 16,true[BOOLEAN],PT0S[TIME_DURATION]) AS c#13]]
+     *       \_EsRelation[airports][abbrev{f}#14, city{f}#20, city_location{f}#21, coun..]
+     * }</pre>
+     */
+    public void testDuplicatedAggsWithSameCannonicalizationInWhereCondition() {
+        assumeTrue("requires FIX FOR CLASSCAST exception to be enabled", EsqlCapabilities.Cap.FIX_STATS_CLASSCAST_EXCEPTION.isEnabled());
+        String query = """
+                FROM airports
+                | STATS a = COUNT(scalerank) WHERE scalerank  > 7,
+                        b = 2*COUNT(scalerank) WHERE 7 < scalerank,
+                        c = COUNT_DISTINCT(scalerank)
+            """;
+
+        LogicalPlan plan = planAirports(query);
+        Project project = as(plan, Project.class);
+        var projections = project.projections();
+        assertThat(projections, hasSize(3));
+
+        assertEquals("a", as(projections.get(0), ReferenceAttribute.class).name());
+        assertEquals("b", as(projections.get(1), ReferenceAttribute.class).name());
+        assertEquals("c", as(projections.get(2), ReferenceAttribute.class).name());
+
+        var eval = as(project.child(), Eval.class);
+
+        assertThat(eval.fields(), hasSize(1));
+        var evalAlias = as(eval.fields().getFirst(), Alias.class);
+        var mul = as(evalAlias.child(), Mul.class);
+        assertEquals("a", as(mul.left(), ReferenceAttribute.class).name());
+        assertEquals(2, as(mul.right(), Literal.class).value());
+        assertEquals("b", evalAlias.name());
+
+        var aggregates = as(as(eval.child(), Limit.class).child(), Aggregate.class).aggregates();
+        assertThat(aggregates, hasSize(2));
+
+        var a = as(aggregates.get(0), Alias.class);
+        var c = as(aggregates.get(1), Alias.class);
+
+        assertEquals("a", a.name());
+        var aField = as(a.child(), Count.class).field();
+        assertEquals("scalerank", as(aField, FieldAttribute.class).name());
+
+        assertEquals("c", c.name());
+        var cField = as(c.child(), CountDistinct.class).field();
+        assertEquals("scalerank", as(cField, FieldAttribute.class).name());
+    }
+
+    /**
+     * Project[[a{r}#5, b{r}#8, c{r}#11]]
+     * \_Eval[[$$COUNTDISTINCT$2*COUNT_DISTINC>$0{r$}#20 * 2[INTEGER] AS a#5, $$COUNTDISTINCT$2*COUNT_DISTINC>$0{r$}#20 * 2[
+     * INTEGER] AS b#8, $$COUNTDISTINCT$2*COUNT_DISTINC>$0{r$}#20 * 2[INTEGER] AS c#11]]
+     *   \_Limit[1000[INTEGER],false,false]
+     *     \_Aggregate[[],[COUNTDISTINCT(scalerank{f}#14,true[BOOLEAN],PT0S[TIME_DURATION],100[INTEGER]) AS $$COUNTDISTINCT$2*COUNT_DI
+     * STINC>$0#20]]
+     *       \_EsRelation[airports][abbrev{f}#12, city{f}#18, city_location{f}#19, coun..]
+     */
+    public void testDuplicatedAggWithFoldableIdenticalExpressions() {
+        assumeTrue("requires FIX FOR CLASSCAST exception to be enabled", EsqlCapabilities.Cap.FIX_STATS_CLASSCAST_EXCEPTION.isEnabled());
+        String query = """
+                FROM airports
+                | STATS a = 2*COUNT_DISTINCT(scalerank, 100),
+                b = 2*COUNT_DISTINCT(scalerank, 220 - 150 + 30),
+                c = 2*COUNT_DISTINCT(scalerank, 1 + 200 - 80 - 20 - 1)
+            """;
+
+        LogicalPlan plan = planAirports(query);
+        Project project = as(plan, Project.class);
+        var projections = project.projections();
+        assertThat(projections, hasSize(3));
+
+        assertEquals("a", as(projections.get(0), ReferenceAttribute.class).name());
+        assertEquals("b", as(projections.get(1), ReferenceAttribute.class).name());
+        assertEquals("c", as(projections.get(2), ReferenceAttribute.class).name());
+
+        var eval = as(project.child(), Eval.class);
+        var aggregates = as(as(eval.child(), Limit.class).child(), Aggregate.class).aggregates();
+
+        assertThat(eval.fields(), hasSize(3));
+        var firstEvalField = as(as(eval.fields().get(0), Alias.class).child(), Mul.class).left();
+        var secondEvalField = as(as(eval.fields().get(1), Alias.class).child(), Mul.class).left();
+        var thirdEvalField = as(as(eval.fields().get(2), Alias.class).child(), Mul.class).left();
+        assertEquals(firstEvalField, secondEvalField);
+        assertEquals(secondEvalField, thirdEvalField);
+
+        assertThat(aggregates, hasSize(1));
+        var countDistinct = as(as(aggregates.get(0), Alias.class).child(), CountDistinct.class);
+        assertEquals("scalerank", as(countDistinct.field(), FieldAttribute.class).name());
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/elastic/elasticsearch/issues/133992 and https://github.com/elastic/elasticsearch/issues/136598, partially.

Missing from this pr that we still need to do: at the moment the runtime part tries to avoid double computations, resulting in exceptions if the plan is correct but not optimal. In other words, queries like:

```sql
from airports 
rename scalerank AS x 
stats  a = count(x), b = count(x) + count(x), c = count_distinct(x)
```

should had never failed at runtime even if the plan was not optimal for repeated aggregations.