### PR TITLE
Mirror upstream elastic/elasticsearch#137382 for AI review (snapshot of HEAD tree)

### DIFF
--- a/docs/changelog/137382.yaml
+++ b/docs/changelog/137382.yaml
@@ -1,0 +1,5 @@
+pr: 137382
+summary: Make field fusion generic
+area: ES|QL
+type: enhancement
+issues: []

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -501,4 +501,5 @@ module org.elasticsearch.server {
     exports org.elasticsearch.index.codec.vectors.es93 to org.elasticsearch.test.knn;
     exports org.elasticsearch.search.crossproject;
     exports org.elasticsearch.index.mapper.blockloader.docvalues;
+    exports org.elasticsearch.index.mapper.blockloader;
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -59,7 +59,9 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.SourceValueFetcherSortedBinaryIndexFieldData;
 import org.elasticsearch.index.fielddata.StoredFieldSortedBinaryIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.Utf8CodePointsFromOrdsBlockLoader;
 import org.elasticsearch.index.query.AutomatonQueryWithDescription;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
@@ -822,7 +824,17 @@ public final class KeywordFieldMapper extends FieldMapper {
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
             if (hasDocValues() && (blContext.fieldExtractPreference() != FieldExtractPreference.STORED || isSyntheticSourceEnabled())) {
-                return new BytesRefsFromOrdsBlockLoader(name());
+                BlockLoaderFunctionConfig cfg = blContext.blockLoaderFunctionConfig();
+                if (cfg == null) {
+                    return new BytesRefsFromOrdsBlockLoader(name());
+                }
+                if (cfg.function() == BlockLoaderFunctionConfig.Function.LENGTH) {
+                    return new Utf8CodePointsFromOrdsBlockLoader(((BlockLoaderFunctionConfig.JustWarnings) cfg).warnings(), name());
+                }
+                throw new UnsupportedOperationException("unknown fusion config [" + cfg.function() + "]");
+            }
+            if (blContext.blockLoaderFunctionConfig() != null) {
+                throw new UnsupportedOperationException("function fusing only supported for doc values");
             }
             if (isStored()) {
                 return new BlockStoredFieldsReader.BytesFromBytesRefsBlockLoader(name());
@@ -844,6 +856,14 @@ public final class KeywordFieldMapper extends FieldMapper {
 
             SourceValueFetcher fetcher = sourceValueFetcher(blContext.sourcePaths(name()), blContext.indexSettings());
             return new BlockSourceReader.BytesRefsBlockLoader(fetcher, sourceBlockLoaderLookup(blContext));
+        }
+
+        @Override
+        public boolean supportsBlockLoaderConfig(BlockLoaderFunctionConfig config, FieldExtractPreference preference) {
+            if (hasDocValues() && (preference != FieldExtractPreference.STORED || isSyntheticSourceEnabled())) {
+                return config.function() == BlockLoaderFunctionConfig.Function.LENGTH;
+            }
+            return false;
         }
 
         private FallbackSyntheticSourceBlockLoader.Reader<?> fallbackSyntheticSourceBlockLoaderReader() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -35,6 +35,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.query.DistanceFeatureQueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.QueryShardException;
@@ -642,6 +643,10 @@ public abstract class MappedFieldType {
         return null;
     }
 
+    public boolean supportsBlockLoaderConfig(BlockLoaderFunctionConfig config, FieldExtractPreference preference) {
+        return false;
+    }
+
     public enum FieldExtractPreference {
         /**
          * Load the field from doc-values into a BlockLoader supporting doc-values.
@@ -709,12 +714,5 @@ public abstract class MappedFieldType {
             return null;
         }
     }
-
-    /**
-     * Marker interface that contains the configuration needed to transform loaded values into blocks.
-     * Is retrievable from the {@link BlockLoaderContext}. The {@link MappedFieldType} can use this configuration to choose the appropriate
-     * implementation for transforming loaded values into blocks.
-     */
-    public interface BlockLoaderFunctionConfig {}
 
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/BlockLoaderFunctionConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/BlockLoaderFunctionConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper.blockloader;
+
+import org.elasticsearch.index.mapper.MappedFieldType;
+
+/**
+ * Configuration needed to transform loaded values into blocks.
+ * {@link MappedFieldType}s will find me in
+ * {@link MappedFieldType.BlockLoaderContext#blockLoaderFunctionConfig()} and
+ * use this configuration to choose the appropriate implementation for
+ * transforming loaded values into blocks.
+ */
+public interface BlockLoaderFunctionConfig {
+    /**
+     * Name used in descriptions.
+     */
+    Function function();
+
+    record JustWarnings(Function function, Warnings warnings) implements BlockLoaderFunctionConfig {}
+
+    enum Function {
+        LENGTH,
+        V_COSINE,
+        V_DOT_PRODUCT,
+        V_HAMMING,
+        V_L1NORM,
+        V_L2NORM,
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/Warnings.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/Warnings.java
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.index.mapper.blockloader.docvalues;
+package org.elasticsearch.index.mapper.blockloader;
 
 /**
  * Warnings returned when loading values for ESQL. These are returned as HTTP 299 headers like so:
@@ -17,7 +17,7 @@ package org.elasticsearch.index.mapper.blockloader.docvalues;
  *  < Warning: 299 Elasticsearch-${ver} "Line 1:27: java.lang.IllegalArgumentException: single-value function encountered multi-value"
  * }</pre>
  */
-interface Warnings {
+public interface Warnings {
     /**
      * Register a warning. ESQL deduplicates and limits the number of warnings returned so it should
      * be fine to blast as many warnings into this as you encounter.

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DenseVectorBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DenseVectorBlockLoader.java
@@ -178,7 +178,7 @@ public class DenseVectorBlockLoader<B extends BlockLoader.Builder> extends Block
 
         @Override
         public String toString() {
-            return "BlockDocValuesReader.FloatDenseVectorValuesBlockReader";
+            return "FloatDenseVectorFromDocValues." + processor.name();
         }
     }
 
@@ -216,7 +216,7 @@ public class DenseVectorBlockLoader<B extends BlockLoader.Builder> extends Block
 
         @Override
         public String toString() {
-            return "BlockDocValuesReader.FloatDenseVectorNormalizedValuesBlockReader";
+            return "FloatDenseVectorFromDocValues.Normalized." + processor.name();
         }
     }
 
@@ -237,7 +237,7 @@ public class DenseVectorBlockLoader<B extends BlockLoader.Builder> extends Block
 
         @Override
         public String toString() {
-            return "BlockDocValuesReader.ByteDenseVectorValuesBlockReader";
+            return "ByteDenseVectorFromDocValues." + processor.name();
         }
     }
 
@@ -255,7 +255,7 @@ public class DenseVectorBlockLoader<B extends BlockLoader.Builder> extends Block
 
         @Override
         public String toString() {
-            return "BlockDocValuesReader.BitDenseVectorValuesBlockReader";
+            return "BitDenseVectorFromDocValues." + processor.name();
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DenseVectorBlockLoaderProcessor.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DenseVectorBlockLoaderProcessor.java
@@ -47,6 +47,8 @@ public interface DenseVectorBlockLoaderProcessor<B extends BlockLoader.Builder> 
         builder.appendNull();
     }
 
+    String name();
+
     /**
      * Processor that appends raw float vectors to a FloatBuilder as multi values.
      */
@@ -73,6 +75,11 @@ public interface DenseVectorBlockLoaderProcessor<B extends BlockLoader.Builder> 
                 builder.appendFloat(b);
             }
             builder.endPositionEntry();
+        }
+
+        @Override
+        public String name() {
+            return "Load";
         }
     }
 
@@ -101,6 +108,11 @@ public interface DenseVectorBlockLoaderProcessor<B extends BlockLoader.Builder> 
         public void process(byte[] vector, BlockLoader.DoubleBuilder builder) {
             double similarity = config.similarityFunction().calculateSimilarity(vector, config.vectorAsBytes());
             builder.appendDouble(similarity);
+        }
+
+        @Override
+        public String name() {
+            return config.similarityFunction().function().toString();
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/Utf8CodePointsFromOrdsBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/Utf8CodePointsFromOrdsBlockLoader.java
@@ -16,11 +16,12 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.UnicodeUtil;
+import org.elasticsearch.index.mapper.blockloader.Warnings;
 
 import java.io.IOException;
 import java.util.Arrays;
 
-import static org.elasticsearch.index.mapper.blockloader.docvalues.Warnings.registerSingleValueWarning;
+import static org.elasticsearch.index.mapper.blockloader.Warnings.registerSingleValueWarning;
 
 /**
  * A count of utf-8 code points for {@code keyword} style fields that are stored as a lookup table.

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/MockWarnings.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/MockWarnings.java
@@ -7,14 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.index.mapper.blockloader.docvalues;
+package org.elasticsearch.index.mapper.blockloader;
 
 import java.util.ArrayList;
 import java.util.List;
 
-// TODO move me once we have more of these loaders
-class MockWarnings implements Warnings {
-    record MockWarning(Class<? extends Exception> exceptionClass, String message) {}
+public class MockWarnings implements Warnings {
+    public record MockWarning(Class<? extends Exception> exceptionClass, String message) {}
 
     private final List<MockWarning> warnings = new ArrayList<>();
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/Utf8CodePointsFromOrdsBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/Utf8CodePointsFromOrdsBlockLoaderTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.TestBlock;
+import org.elasticsearch.index.mapper.blockloader.MockWarnings;
 import org.hamcrest.Matcher;
 
 import java.io.IOException;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ShardContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ShardContext.java
@@ -13,6 +13,7 @@ import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.SourceLoader;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.search.sort.SortAndFormats;
 import org.elasticsearch.search.sort.SortBuilder;
 
@@ -58,7 +59,7 @@ public interface ShardContext extends RefCounted {
         String name,
         boolean asUnsupportedSource,
         MappedFieldType.FieldExtractPreference fieldExtractPreference,
-        MappedFieldType.BlockLoaderFunctionConfig blockLoaderFunctionConfig
+        BlockLoaderFunctionConfig blockLoaderFunctionConfig
     );
 
     /**

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
@@ -43,6 +43,7 @@ import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.SourceLoader;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.indices.CrankyCircuitBreakerService;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.sort.SortAndFormats;
@@ -467,7 +468,7 @@ public class LuceneSourceOperatorTests extends SourceOperatorTestCase {
             String name,
             boolean asUnsupportedSource,
             MappedFieldType.FieldExtractPreference fieldExtractPreference,
-            MappedFieldType.BlockLoaderFunctionConfig blockLoaderFunctionConfig
+            BlockLoaderFunctionConfig blockLoaderFunctionConfig
         ) {
             throw new UnsupportedOperationException();
         }

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushExpressionToLoadIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushExpressionToLoadIT.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.single_node;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.test.MapMatcher;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.esql.AssertWarnings;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.qa.rest.ProfileLogger;
+import org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.elasticsearch.test.ListMatcher.matchesList;
+import static org.elasticsearch.test.MapMatcher.assertMap;
+import static org.elasticsearch.test.MapMatcher.matchesMap;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.entityToMap;
+import static org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase.requestObjectBuilder;
+import static org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase.runEsql;
+import static org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT.commonProfile;
+import static org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT.fixTypesOnProfile;
+import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.startsWith;
+
+/**
+ * Tests for pushing expressions into field loading.
+ */
+@ThreadLeakFilters(filters = TestClustersThreadFilter.class)
+public class PushExpressionToLoadIT extends ESRestTestCase {
+    @ClassRule
+    public static ElasticsearchCluster cluster = Clusters.testCluster(spec -> spec.plugin("inference-service-test"));
+
+    @Rule(order = Integer.MIN_VALUE)
+    public ProfileLogger profileLogger = new ProfileLogger();
+
+    @Before
+    public void checkPushCapability() throws IOException {
+        assumeTrue(
+            "requires " + EsqlCapabilities.Cap.VECTOR_SIMILARITY_FUNCTIONS_PUSHDOWN.capabilityName(),
+            clusterHasCapability(
+                "POST",
+                "_query",
+                List.of(),
+                List.of(EsqlCapabilities.Cap.VECTOR_SIMILARITY_FUNCTIONS_PUSHDOWN.capabilityName())
+            ).orElseGet(() -> false)
+        );
+    }
+
+    public void testLengthToKeyword() throws IOException {
+        String value = "v".repeat(between(0, 256));
+        test(
+            justType("keyword"),
+            b -> b.field("test", value),
+            "| EVAL test = LENGTH(test)",
+            matchesList().item(value.length()),
+            matchesMap().entry("test:column_at_a_time:Utf8CodePointsFromOrds.Singleton", 1)
+        );
+    }
+
+    public void testLengthNotPushedToWildcard() throws IOException {
+        String value = "v".repeat(between(0, 256));
+        test(
+            justType("wildcard"),
+            b -> b.field("test", value),
+            "| EVAL test = LENGTH(test)",
+            matchesList().item(value.length()),
+            matchesMap().entry("test:column_at_a_time:BlockDocValuesReader.BytesCustom", 1)
+        );
+    }
+
+    public void testLengthNotPushedToText() throws IOException {
+        String value = "v".repeat(between(0, 256));
+        test(
+            justType("text"),
+            b -> b.field("test", value),
+            "| EVAL test = LENGTH(test)",
+            matchesList().item(value.length()),
+            matchesMap().entry("test:column_at_a_time:null", 1)
+                .entry("stored_fields[requires_source:true, fields:0, sequential: false]", 1)
+                .entry("test:row_stride:BlockSourceReader.Bytes", 1)
+        );
+    }
+
+    /**
+     * Tests {@code LENGTH} on a field that comes from a {@code LOOKUP JOIN}.
+     */
+    public void testLengthNotPushedToLookupJoinKeyword() throws IOException {
+        initLookupIndex();
+        test(
+            b -> b.startObject("main_matching").field("type", "keyword").endObject(),
+            b -> b.field("main_matching", "lookup"),
+            """
+                | LOOKUP JOIN lookup ON matching == main_matching
+                | EVAL test = LENGTH(test)
+                """,
+            matchesList().item(1),
+            matchesMap().entry("main_matching:column_at_a_time:BytesRefsFromOrds.Singleton", 1), //
+            sig -> {}
+        );
+    }
+
+    /**
+     * Tests {@code LENGTH} on a field that comes from a {@code LOOKUP JOIN} with
+     * the added complexity that the field also exists in the index, but we're not
+     * querying it.
+     */
+    public void testLengthNotPushedToLookupJoinKeywordSameName() throws IOException {
+        assumeFalse("fix in 137679 - we push to the index but that's just wrong!", true);
+        String value = "v".repeat(between(0, 256));
+        initLookupIndex();
+        test(b -> {
+            b.startObject("test").field("type", "keyword").endObject();
+            b.startObject("main_matching").field("type", "keyword").endObject();
+        },
+            b -> b.field("test", value).field("main_matching", "lookup"),
+            """
+                | DROP test
+                | LOOKUP JOIN lookup ON matching == main_matching
+                | EVAL test = LENGTH(test)
+                """,
+            matchesList().item(1), // <--- This is incorrectly returning value.length()
+            matchesMap().entry("main_matching:column_at_a_time:BytesRefsFromOrds.Singleton", 1),
+            // ^^^^ This is incorrectly returning test:column_at_a_time:Utf8CodePointsFromOrds.Singleton
+            sig -> {}
+        );
+    }
+
+    public void testVCosine() throws IOException {
+        test(
+            justType("dense_vector"),
+            b -> b.startArray("test").value(128).value(128).value(0).endArray(),
+            "| EVAL test = V_COSINE(test, [0, 255, 255])",
+            matchesList().item(0.5),
+            matchesMap().entry("test:column_at_a_time:FloatDenseVectorFromDocValues.Normalized.V_COSINE", 1)
+        );
+    }
+
+    public void testVHammingToByte() throws IOException {
+        test(
+            b -> b.startObject("test").field("type", "dense_vector").field("element_type", "byte").endObject(),
+            b -> b.startArray("test").value(100).value(100).value(0).endArray(),
+            "| EVAL test = V_HAMMING(test, [0, 100, 100])",
+            matchesList().item(6.0),
+            matchesMap().entry("test:column_at_a_time:ByteDenseVectorFromDocValues.V_HAMMING", 1)
+        );
+    }
+
+    public void testVHammingToBit() throws IOException {
+        test(
+            b -> b.startObject("test").field("type", "dense_vector").field("element_type", "bit").endObject(),
+            b -> b.startArray("test").value(100).value(100).value(0).endArray(),
+            "| EVAL test = V_HAMMING(test, [0, 100, 100])",
+            matchesList().item(6.0),
+            matchesMap().entry("test:column_at_a_time:BitDenseVectorFromDocValues.V_HAMMING", 1)
+        );
+    }
+
+    private void test(
+        CheckedConsumer<XContentBuilder, IOException> mapping,
+        CheckedConsumer<XContentBuilder, IOException> doc,
+        String eval,
+        Matcher<?> expectedValue,
+        MapMatcher expectedLoaders
+    ) throws IOException {
+        test(
+            mapping,
+            doc,
+            eval,
+            expectedValue,
+            expectedLoaders,
+            sig -> assertMap(
+                sig,
+                matchesList().item("LuceneSourceOperator")
+                    .item("ValuesSourceReaderOperator") // the real work is here, checkOperatorProfile checks the status
+                    .item("EvalOperator") // this one just renames the field
+                    .item("AggregationOperator")
+                    .item("ExchangeSinkOperator")
+            )
+        );
+    }
+
+    private void test(
+        CheckedConsumer<XContentBuilder, IOException> mapping,
+        CheckedConsumer<XContentBuilder, IOException> doc,
+        String eval,
+        Matcher<?> expectedValue,
+        MapMatcher expectedLoaders,
+        Consumer<List<String>> assertDataNodeSig
+    ) throws IOException {
+        indexValue(mapping, doc);
+        RestEsqlTestCase.RequestObjectBuilder builder = requestObjectBuilder().query("""
+            FROM test
+            """ + eval + """
+            | STATS test = VALUES(test)
+            """);
+        /*
+         * TODO if you just do KEEP test then the load is in the data node reduce driver and not merged:
+         *  \_ProjectExec[[test{f}#7]]
+         *    \_FieldExtractExec[test{f}#7]<[],[]>
+         *      \_EsQueryExec[test], indexMode[standard]]
+         *  \_ExchangeSourceExec[[test{f}#7],false]}, {cluster_name=test-cluster, node_name=test-cluster-0, descrip
+         *  \_ProjectExec[[test{r}#3]]
+         *    \_EvalExec[[LENGTH(test{f}#7) AS test#3]]
+         *      \_LimitExec[1000[INTEGER],50]
+         *        \_ExchangeSourceExec[[test{f}#7],false]}], query={to
+         */
+        builder.profile(true);
+        Map<String, Object> result = runEsql(builder, new AssertWarnings.NoWarnings(), profileLogger, RestEsqlTestCase.Mode.SYNC);
+
+        assertResultMap(
+            result,
+            getResultMatcher(result).entry(
+                "profile",
+                matchesMap() //
+                    .entry("drivers", instanceOf(List.class))
+                    .entry("plans", instanceOf(List.class))
+                    .entry("planning", matchesMap().extraOk())
+                    .entry("query", matchesMap().extraOk())
+            ),
+            matchesList().item(matchesMap().entry("name", "test").entry("type", any(String.class))),
+            matchesList().item(expectedValue)
+        );
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> profiles = (List<Map<String, Object>>) ((Map<String, Object>) result.get("profile")).get("drivers");
+        for (Map<String, Object> p : profiles) {
+            fixTypesOnProfile(p);
+            assertThat(p, commonProfile());
+            List<String> sig = new ArrayList<>();
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> operators = (List<Map<String, Object>>) p.get("operators");
+            for (Map<String, Object> o : operators) {
+                sig.add(checkOperatorProfile(o, expectedLoaders));
+            }
+            String description = p.get("description").toString();
+            switch (description) {
+                case "data" -> {
+                    logger.info("data {}", sig);
+                    assertDataNodeSig.accept(sig);
+                }
+                case "node_reduce" -> logger.info("node_reduce {}", sig);
+                case "final" -> logger.info("final {}", sig);
+                default -> throw new IllegalArgumentException("can't match " + description);
+            }
+        }
+    }
+
+    private void indexValue(CheckedConsumer<XContentBuilder, IOException> mapping, CheckedConsumer<XContentBuilder, IOException> doc)
+        throws IOException {
+        try {
+            // Delete the index if it has already been created.
+            client().performRequest(new Request("DELETE", "test"));
+        } catch (ResponseException e) {
+            if (e.getResponse().getStatusLine().getStatusCode() != 404) {
+                throw e;
+            }
+        }
+
+        Request createIndex = new Request("PUT", "test");
+        try (XContentBuilder config = JsonXContent.contentBuilder()) {
+            config.startObject();
+            config.startObject("settings");
+            {
+                config.startObject("index");
+                config.field("number_of_shards", 1);
+                config.endObject();
+            }
+            config.endObject();
+            config.startObject("mappings");
+            {
+                config.startObject("properties");
+                mapping.accept(config);
+                config.endObject();
+            }
+            config.endObject();
+
+            createIndex.setJsonEntity(Strings.toString(config.endObject()));
+        }
+        Response createResponse = client().performRequest(createIndex);
+        assertThat(
+            entityToMap(createResponse.getEntity(), XContentType.JSON),
+            matchesMap().entry("shards_acknowledged", true).entry("index", "test").entry("acknowledged", true)
+        );
+
+        Request bulk = new Request("POST", "/_bulk");
+        bulk.addParameter("refresh", "");
+        try (XContentBuilder docJson = JsonXContent.contentBuilder()) {
+            docJson.startObject();
+            doc.accept(docJson);
+            docJson.endObject();
+            bulk.setJsonEntity("""
+                    {"create":{"_index":"test"}}
+                """ + Strings.toString(docJson) + "\n");
+        }
+        Response bulkResponse = client().performRequest(bulk);
+        assertThat(entityToMap(bulkResponse.getEntity(), XContentType.JSON), matchesMap().entry("errors", false).extraOk());
+    }
+
+    private void initLookupIndex() throws IOException {
+        if (indexExists("lookup")) {
+            return;
+        }
+        Request createIndex = new Request("PUT", "lookup");
+        try (XContentBuilder config = JsonXContent.contentBuilder()) {
+            config.startObject();
+            config.startObject("settings");
+            {
+                config.startObject("index");
+                config.field("number_of_shards", 1);
+                config.field("mode", "lookup");
+                config.endObject();
+            }
+            config.endObject();
+            config.startObject("mappings");
+            {
+                config.startObject("properties");
+                config.startObject("matching").field("type", "keyword").endObject();
+                config.startObject("test").field("type", "keyword").endObject();
+                config.endObject();
+            }
+            config.endObject();
+
+            createIndex.setJsonEntity(Strings.toString(config.endObject()));
+        }
+        Response createResponse = client().performRequest(createIndex);
+        assertThat(
+            entityToMap(createResponse.getEntity(), XContentType.JSON),
+            matchesMap().entry("shards_acknowledged", true).entry("index", "lookup").entry("acknowledged", true)
+        );
+
+        Request bulk = new Request("POST", "/_bulk");
+        bulk.addParameter("refresh", "");
+        bulk.setJsonEntity("""
+                {"create":{"_index":"lookup"}}
+                {"test": "a", "matching": "lookup"}
+            """);
+        Response bulkResponse = client().performRequest(bulk);
+        assertThat(entityToMap(bulkResponse.getEntity(), XContentType.JSON), matchesMap().entry("errors", false).extraOk());
+    }
+
+    private CheckedConsumer<XContentBuilder, IOException> justType(String type) {
+        return b -> b.startObject("test").field("type", type).endObject();
+    }
+
+    private static String checkOperatorProfile(Map<String, Object> o, MapMatcher expectedLoaders) {
+        String name = (String) o.get("operator");
+        name = PushQueriesIT.TO_NAME.matcher(name).replaceAll("");
+        if (name.equals("ValuesSourceReaderOperator")) {
+            MapMatcher expectedOp = matchesMap().entry("operator", startsWith(name))
+                .entry("status", matchesMap().entry("readers_built", expectedLoaders).extraOk());
+            assertMap(o, expectedOp);
+        }
+        return name;
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    @Override
+    protected boolean preserveClusterUponCompletion() {
+        // Preserve the cluser to speed up the semantic_text tests
+        return true;
+    }
+
+    private static boolean setupEmbeddings = false;
+
+    private void setUpTextEmbeddingInferenceEndpoint() throws IOException {
+        setupEmbeddings = true;
+        Request request = new Request("PUT", "_inference/text_embedding/test");
+        request.setJsonEntity("""
+                  {
+                   "service": "text_embedding_test_service",
+                   "service_settings": {
+                     "model": "my_model",
+                     "api_key": "abc64",
+                     "dimensions": 128
+                   },
+                   "task_settings": {
+                   }
+                 }
+            """);
+        adminClient().performRequest(request);
+    }
+}

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
@@ -515,7 +515,7 @@ public class PushQueriesIT extends ESRestTestCase {
             }""";
     }
 
-    private static final Pattern TO_NAME = Pattern.compile("\\[.+", Pattern.DOTALL);
+    static final Pattern TO_NAME = Pattern.compile("\\[.+", Pattern.DOTALL);
 
     private static String checkOperatorProfile(Map<String, Object> o, Matcher<String> query) {
         String name = (String) o.get("operator");

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -52,7 +52,9 @@ import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.geometry.utils.Geohash;
 import org.elasticsearch.h3.H3;
 import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.RoutingPathFields;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
@@ -346,6 +348,15 @@ public final class EsqlTestUtils {
         @Override
         public boolean hasExactSubfield(FieldName field) {
             return exists(field);
+        }
+
+        @Override
+        public boolean supportsLoaderConfig(
+            FieldName name,
+            BlockLoaderFunctionConfig config,
+            MappedFieldType.FieldExtractPreference preference
+        ) {
+            return true;
         }
 
         @Override

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -196,6 +196,14 @@ emp_no:integer | last_name:keyword | f_l:keyword
 10010 | Piveteau  | eau
 ;
 
+aggregate length
+FROM employees
+| STATS SUM(LENGTH(last_name));
+
+SUM(LENGTH(last_name)):long
+720
+;
+
 substring nested negative start
 from employees | where emp_no <= 10010 | eval f_l = substring(substring(last_name, -3),-1) | keep emp_no, last_name, f_l;
 ignoreOrder:true

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/BlockLoaderWarnings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/BlockLoaderWarnings.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function;
+
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * Shim between the {@link org.elasticsearch.index.mapper.blockloader.Warnings} in server and
+ * our {@link Warnings}. Also adds laziness because our {@link Warnings} are a little expensive
+ * on creation and {@link org.elasticsearch.index.mapper.blockloader.Warnings} wants to be
+ * cheap to create.
+ */
+public class BlockLoaderWarnings implements org.elasticsearch.index.mapper.blockloader.Warnings {
+    private final DriverContext.WarningsMode warningsMode;
+    private final Source source;
+    private Warnings delegate;
+
+    public BlockLoaderWarnings(DriverContext.WarningsMode warningsMode, Source source) {
+        this.warningsMode = warningsMode;
+        this.source = source;
+    }
+
+    @Override
+    public void registerException(Class<? extends Exception> exceptionClass, String message) {
+        if (delegate == null) {
+            delegate = Warnings.createOnlyWarnings(
+                warningsMode,
+                source.source().getLineNumber(),
+                source.source().getColumnNumber(),
+                source.text()
+            );
+        }
+        delegate.registerException(exceptionClass, message);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/blockloader/BlockLoaderExpression.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/blockloader/BlockLoaderExpression.java
@@ -7,17 +7,64 @@
 
 package org.elasticsearch.xpack.esql.expression.function.blockloader;
 
-import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.stats.SearchStats;
 
 /**
- * {@link org.elasticsearch.xpack.esql.core.expression.Expression}s that can be implemented as part of value loading implement this
- * interface to provide the {@link MappedFieldType.BlockLoaderFunctionConfig} that will be used to load and
- * transform the value of the field.
+ * {@link Expression} that can be "pushed" into value loading. Most of the time
+ * we load values into {@link Block}s and then run the expressions on them, but
+ * sometimes it's worth short-circuiting this process and running the expression
+ * in the tight loop we use for loading:
+ * <ul>
+ *     <li>
+ *         {@code V_COSINE(vector, [constant_vector])} - vector is ~512 floats
+ *         and V_COSINE is one double. We can find the similarity without any
+ *         copies if we combine.
+ *     </li>
+ *     <li>
+ *         {@code ST_CENTROID(shape)} - shapes can be quite large. Centroids
+ *         are just one point.
+ *     </li>
+ *     <li>
+ *         {@code LENGTH(string)} - strings can be quite long, but string length
+ *         is always an int. For more fun, {@code keyword}s are usually stored
+ *         using a dictionary, and it's <strong>fairly</strong> easy to optimize
+ *         running {@code LENGTH} once per dictionary entry.
+ *     </li>
+ *     <li>
+ *         {@code MV_COUNT(anything)} - counts are always integers.
+ *     </li>
+ *     <li>
+ *         {@code MV_MIN} and {@code MV_MAX} - loads much fewer data for
+ *         multivalued fields.
+ *     </li>
+ * </ul>
  */
 public interface BlockLoaderExpression {
+    /**
+     * The field and loading configuration that replaces this expression, effectively
+     * "fusing" the expression into the load. Or null if the fusion isn't possible.
+     * <p>
+     *     {@link SearchStats#supportsLoaderConfig} checks that the configuration is
+     *     supported by all field mappers. Callers to this method <strong>must</strong>
+     *     call that to confirm that configurations returned are supported. Implementations
+     *     of this method do not need to call it, though they <strong>may</strong> use
+     *     methods like {@link SearchStats#hasDocValues} and {@link SearchStats#isIndexed}
+     *     as preflight checks. They <strong>should</strong> use those methods if it is
+     *     expensive to build the {@link BlockLoaderFunctionConfig}.
+     * </p>
+     */
+    @Nullable
+    PushedBlockLoaderExpression tryPushToFieldLoading(SearchStats stats);
 
     /**
-     * Returns the configuration that will be used to load the value of the field and transform it
+     * Expression "fused" to the block loader.
+     * @param field the field whose load we're fusing into
+     * @param config the expression's configuration
      */
-    MappedFieldType.BlockLoaderFunctionConfig getBlockLoaderFunctionConfig();
+    record PushedBlockLoaderExpression(FieldAttribute field, BlockLoaderFunctionConfig config) {}
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Length.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Length.java
@@ -12,15 +12,21 @@ import org.apache.lucene.util.UnicodeUtil;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.compute.ann.Evaluator;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.BlockLoaderWarnings;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.expression.function.blockloader.BlockLoaderExpression;
 import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
+import org.elasticsearch.xpack.esql.stats.SearchStats;
 
 import java.io.IOException;
 import java.util.List;
@@ -28,7 +34,7 @@ import java.util.List;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.DEFAULT;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
 
-public class Length extends UnaryScalarFunction {
+public class Length extends UnaryScalarFunction implements BlockLoaderExpression {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Length", Length::new);
 
     @FunctionInfo(
@@ -89,5 +95,17 @@ public class Length extends UnaryScalarFunction {
     @Override
     public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         return new LengthEvaluator.Factory(source(), toEvaluator.apply(field()));
+    }
+
+    @Override
+    public PushedBlockLoaderExpression tryPushToFieldLoading(SearchStats stats) {
+        if (field instanceof FieldAttribute f) {
+            BlockLoaderWarnings warnings = new BlockLoaderWarnings(DriverContext.WarningsMode.COLLECT, source());
+            return new PushedBlockLoaderExpression(
+                f,
+                new BlockLoaderFunctionConfig.JustWarnings(BlockLoaderFunctionConfig.Function.LENGTH, warnings)
+            );
+        }
+        return null;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/CosineSimilarity.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/CosineSimilarity.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.vector;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
@@ -39,6 +40,11 @@ public class CosineSimilarity extends VectorSimilarityFunction {
         @Override
         public float calculateSimilarity(float[] leftVector, float[] rightVector) {
             return VectorUtil.cosine(leftVector, rightVector);
+        }
+
+        @Override
+        public BlockLoaderFunctionConfig.Function function() {
+            return BlockLoaderFunctionConfig.Function.V_COSINE;
         }
     };
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/DotProduct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/DotProduct.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.vector;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
@@ -40,6 +41,11 @@ public class DotProduct extends VectorSimilarityFunction {
         @Override
         public float calculateSimilarity(float[] leftVector, float[] rightVector) {
             return VectorUtil.dotProduct(leftVector, rightVector);
+        }
+
+        @Override
+        public BlockLoaderFunctionConfig.Function function() {
+            return BlockLoaderFunctionConfig.Function.V_DOT_PRODUCT;
         }
     };
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Hamming.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Hamming.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.vector;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
@@ -36,6 +37,11 @@ public class Hamming extends VectorSimilarityFunction {
         public float calculateSimilarity(float[] leftVector, float[] rightVector) {
             throw new UnsupportedOperationException("Hamming distance is not supported for float vectors");
         }
+
+        @Override
+        public BlockLoaderFunctionConfig.Function function() {
+            return BlockLoaderFunctionConfig.Function.V_HAMMING;
+        }
     };
     public static final DenseVectorFieldMapper.SimilarityFunction EVALUATOR_SIMILARITY_FUNCTION =
         new DenseVectorFieldMapper.SimilarityFunction() {
@@ -55,6 +61,11 @@ public class Hamming extends VectorSimilarityFunction {
                     b[i] = (byte) rightVector[i];
                 }
                 return Hamming.calculateSimilarity(a, b);
+            }
+
+            @Override
+            public BlockLoaderFunctionConfig.Function function() {
+                return BlockLoaderFunctionConfig.Function.V_HAMMING;
             }
         };
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/L1Norm.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/L1Norm.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.expression.function.vector;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
@@ -48,6 +49,11 @@ public class L1Norm extends VectorSimilarityFunction {
                 result += Math.abs(leftVector[i] - rightVector[i]);
             }
             return result;
+        }
+
+        @Override
+        public BlockLoaderFunctionConfig.Function function() {
+            return BlockLoaderFunctionConfig.Function.V_L1NORM;
         }
     };
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/L2Norm.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/L2Norm.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.vector;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
@@ -36,6 +37,11 @@ public class L2Norm extends VectorSimilarityFunction {
         @Override
         public float calculateSimilarity(float[] leftVector, float[] rightVector) {
             return (float) Math.sqrt(VectorUtil.squareDistance(leftVector, rightVector));
+        }
+
+        @Override
+        public BlockLoaderFunctionConfig.Function function() {
+            return BlockLoaderFunctionConfig.Function.V_L2NORM;
         }
     };
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/VectorSimilarityFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/VectorSimilarityFunction.java
@@ -18,9 +18,9 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 import org.elasticsearch.xpack.esql.expression.function.blockloader.BlockLoaderExpression;
+import org.elasticsearch.xpack.esql.stats.SearchStats;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -207,17 +208,35 @@ public abstract class VectorSimilarityFunction extends BinaryScalarFunction
     }
 
     @Override
-    public MappedFieldType.BlockLoaderFunctionConfig getBlockLoaderFunctionConfig() {
-        // PushDownVectorSimilarityFunctions checks that one of the sides is a literal
-        Literal literal = (Literal) (left() instanceof Literal ? left() : right());
-        @SuppressWarnings("unchecked")
-        List<Number> numberList = (List<Number>) literal.value();
-        float[] vector = new float[numberList.size()];
-        for (int i = 0; i < numberList.size(); i++) {
-            vector[i] = numberList.get(i).floatValue();
+    public final PushedBlockLoaderExpression tryPushToFieldLoading(SearchStats stats) {
+        // Bail if we're not directly comparing a field with a literal.
+        Literal literal;
+        FieldAttribute field;
+        if (left() instanceof Literal lit && right() instanceof FieldAttribute f) {
+            literal = lit;
+            field = f;
+        } else if (left() instanceof FieldAttribute f && right() instanceof Literal lit) {
+            literal = lit;
+            field = f;
+        } else {
+            return null;
         }
 
-        return new DenseVectorFieldMapper.VectorSimilarityFunctionConfig(getSimilarityFunction(), vector);
+        // Bail if the field isn't indexed.
+        if (stats.isIndexed(field.fieldName()) == false) {
+            return null;
+        }
+
+        List<?> vectorList = (List<?>) literal.value();
+        float[] vectorArray = new float[vectorList.size()];
+        for (int i = 0; i < vectorList.size(); i++) {
+            vectorArray[i] = ((Number) vectorList.get(i)).floatValue();
+        }
+
+        return new PushedBlockLoaderExpression(
+            field,
+            new DenseVectorFieldMapper.VectorSimilarityFunctionConfig(getSimilarityFunction(), vectorArray)
+        );
     }
 
     interface VectorValueProvider extends Releasable {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceStringCasingW
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.IgnoreNullMetrics;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.InferIsNotNull;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.InferNonNullAggConstraint;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.PushDownVectorSimilarityFunctions;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.PushExpressionsToFieldLoad;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundTo;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceFieldWithConstantOrNull;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceTopNWithLimitAndSort;
@@ -71,7 +71,7 @@ public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<Logical
             )
         );
         if (EsqlCapabilities.Cap.VECTOR_SIMILARITY_FUNCTIONS_PUSHDOWN.isEnabled()) {
-            rules.add(new PushDownVectorSimilarityFunctions());
+            rules.add(new PushExpressionsToFieldLoad());
         }
 
         return new Batch<>("Local rewrite", Limiter.ONCE, rules.toArray(Rule[]::new));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -45,6 +45,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NestedLookup;
 import org.elasticsearch.index.mapper.SourceLoader;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
@@ -194,7 +195,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
         }
 
         // Apply any block loader function if present
-        MappedFieldType.BlockLoaderFunctionConfig functionConfig = null;
+        BlockLoaderFunctionConfig functionConfig = null;
         if (attr instanceof FieldAttribute fieldAttr && fieldAttr.field() instanceof FunctionEsField functionEsField) {
             functionConfig = functionEsField.functionConfig();
         }
@@ -488,7 +489,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             String name,
             boolean asUnsupportedSource,
             MappedFieldType.FieldExtractPreference fieldExtractPreference,
-            MappedFieldType.BlockLoaderFunctionConfig blockLoaderFunctionConfig
+            BlockLoaderFunctionConfig blockLoaderFunctionConfig
         ) {
             if (asUnsupportedSource) {
                 return BlockLoader.CONSTANT_NULLS;
@@ -535,7 +536,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
                 }
 
                 @Override
-                public MappedFieldType.BlockLoaderFunctionConfig blockLoaderFunctionConfig() {
+                public BlockLoaderFunctionConfig blockLoaderFunctionConfig() {
                     return blockLoaderFunctionConfig;
                 }
             });

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchContextStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchContextStats.java
@@ -28,6 +28,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberFieldType;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -156,6 +157,31 @@ public class SearchContextStats implements SearchStats {
     @Override
     public boolean hasDocValues(FieldName field) {
         return cache.computeIfAbsent(field.string(), this::makeFieldStats).config.hasDocValues;
+    }
+
+    @Override
+    public boolean supportsLoaderConfig(
+        FieldName name,
+        BlockLoaderFunctionConfig config,
+        MappedFieldType.FieldExtractPreference preference
+    ) {
+        for (SearchExecutionContext context : contexts) {
+            MappedFieldType ft = context.getFieldType(name.string());
+            if (ft == null) {
+                /*
+                 * Missing fields are always null no matter what we try to push so they
+                 * should work, but we need this check here to prevent actually pushing
+                 * to a LOOKUP JOIN. If the field comes from a LOOKUP JOIN  then it'll
+                 * show up as missing here. And we can't push to those fields. Yet.
+                 */
+                return false;
+            }
+            if (ft.supportsBlockLoaderConfig(config, preference) == false) {
+                // If any one field doesn't support the loader config we'll disable pushing the expression to the field
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
@@ -8,7 +8,8 @@
 package org.elasticsearch.xpack.esql.stats;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute.FieldName;
 
 /**
@@ -41,10 +42,15 @@ public interface SearchStats {
     boolean canUseEqualityOnSyntheticSourceDelegate(FieldName name, String value);
 
     /**
+     * Do all fields with the matching name support this loader config?
+     */
+    boolean supportsLoaderConfig(FieldName name, BlockLoaderFunctionConfig config, MappedFieldType.FieldExtractPreference preference);
+
+    /**
      * Returns the value for a field if it's a constant (eg. a constant_keyword with only one value for the involved indices).
      * NULL if the field is not a constant.
      */
-    default String constantValue(FieldAttribute.FieldName name) {
+    default String constantValue(FieldName name) {
         return null;
     }
 
@@ -70,6 +76,15 @@ public interface SearchStats {
 
         @Override
         public boolean hasExactSubfield(FieldName field) {
+            return false;
+        }
+
+        @Override
+        public boolean supportsLoaderConfig(
+            FieldName name,
+            BlockLoaderFunctionConfig config,
+            MappedFieldType.FieldExtractPreference preference
+        ) {
             return false;
         }
 
@@ -132,6 +147,15 @@ public interface SearchStats {
         @Override
         public boolean hasExactSubfield(FieldName field) {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean supportsLoaderConfig(
+            FieldName name,
+            BlockLoaderFunctionConfig config,
+            MappedFieldType.FieldExtractPreference preference
+        ) {
+            return false;
         }
 
         @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -37,7 +38,9 @@ import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.esql.expression.function.fulltext.SingleFieldFullTextFunction;
 import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Case;
 import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
@@ -117,6 +120,8 @@ import static org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRule
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -1105,9 +1110,9 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
      * EsqlProject[[!alias_integer, boolean{f}#7, byte{f}#8, constant_keyword-foo{f}#9, date{f}#10, date_nanos{f}#11, dense_vector
      * {f}#26, double{f}#12, float{f}#13, half_float{f}#14, integer{f}#16, ip{f}#17, keyword{f}#18, long{f}#19, scaled_float{f}#15,
      * semantic_text{f}#25, short{f}#21, text{f}#22, unsigned_long{f}#20, version{f}#23, wildcard{f}#24, s{r}#5]]
-     * \_Eval[[$$dense_vector$DOTPRODUCT$27{f}#27 AS s#5]]
+     * \_Eval[[$$dense_vector$V_DOT_PRODUCT$27{f}#27 AS s#5]]
      *   \_Limit[1000[INTEGER],false,false]
-     *     \_EsRelation[test_all][$$dense_vector$DOTPRODUCT$27{f}#27, !alias_integer,
+     *     \_EsRelation[test_all][$$dense_vector$V_DOT_PRODUCT$27{f}#27, !alias_integer,
      */
     public void testVectorFunctionsReplaced() {
         assumeTrue("requires similarity functions", EsqlCapabilities.Cap.VECTOR_SIMILARITY_FUNCTIONS_PUSHDOWN.isEnabled());
@@ -1121,9 +1126,9 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         // EsqlProject[[!alias_integer, boolean{f}#7, byte{f}#8, ... s{r}#5]]
         var project = as(plan, EsqlProject.class);
         // Does not contain the extracted field
-        assertFalse(Expressions.names(project.projections()).stream().anyMatch(s -> s.startsWith("$$dense_vector$DotProduct")));
+        assertFalse(Expressions.names(project.projections()).stream().anyMatch(s -> s.startsWith("$$dense_vector$V_DOT_PRODUCT$")));
 
-        // Eval[[$$dense_vector$DOTPRODUCT$27{f}#27 AS s#5]]
+        // Eval[[$$dense_vector$V_DOT_PRODUCT$27{f}#27 AS s#5]]
         var eval = as(project.child(), Eval.class);
         assertThat(eval.fields(), hasSize(1));
         var alias = as(eval.fields().getFirst(), Alias.class);
@@ -1132,7 +1137,7 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         // Check replaced field attribute
         FieldAttribute fieldAttr = (FieldAttribute) alias.child();
         assertThat(fieldAttr.fieldName().string(), equalTo("dense_vector"));
-        assertThat(fieldAttr.name(), startsWith("$$dense_vector$DotProduct"));
+        assertThat(fieldAttr.name(), startsWith("$$dense_vector$V_DOT_PRODUCT$"));
         var field = as(fieldAttr.field(), FunctionEsField.class);
         var blockLoaderFunctionConfig = as(field.functionConfig(), DenseVectorFieldMapper.VectorSimilarityFunctionConfig.class);
         assertThat(blockLoaderFunctionConfig.similarityFunction(), is(DotProduct.SIMILARITY_FUNCTION));
@@ -1188,7 +1193,7 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         // Check replaced field attribute
         FieldAttribute fieldAttr = (FieldAttribute) alias.child();
         assertThat(fieldAttr.fieldName().string(), equalTo("dense_vector"));
-        assertThat(fieldAttr.name(), startsWith("$$dense_vector$DotProduct"));
+        assertThat(fieldAttr.name(), startsWith("$$dense_vector$V_DOT_PRODUCT$"));
         var field = as(fieldAttr.field(), FunctionEsField.class);
         var blockLoaderFunctionConfig = as(field.functionConfig(), DenseVectorFieldMapper.VectorSimilarityFunctionConfig.class);
         assertThat(blockLoaderFunctionConfig.similarityFunction(), is(DotProduct.SIMILARITY_FUNCTION));
@@ -1303,7 +1308,7 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         // Check left side is the replaced field attribute
         var fieldAttr = as(greaterThan.left(), FieldAttribute.class);
         assertThat(fieldAttr.fieldName().string(), equalTo("dense_vector"));
-        assertThat(fieldAttr.name(), startsWith("$$dense_vector$DotProduct"));
+        assertThat(fieldAttr.name(), startsWith("$$dense_vector$V_DOT_PRODUCT$"));
         var field = as(fieldAttr.field(), FunctionEsField.class);
         var blockLoaderFunctionConfig = as(field.functionConfig(), DenseVectorFieldMapper.VectorSimilarityFunctionConfig.class);
         assertThat(blockLoaderFunctionConfig.similarityFunction(), is(DotProduct.SIMILARITY_FUNCTION));
@@ -1314,7 +1319,7 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         assertThat(literal.value(), equalTo(0.5));
         assertThat(literal.dataType(), is(DataType.DOUBLE));
 
-        // EsRelation[test_all][$$dense_vector$DotProduct$26{f}#26, !alias_integer, ..]
+        // EsRelation[test_all][$$dense_vector$V_DOT_PRODUCT$26{f}#26, !alias_integer, ..]
         var esRelation = as(filter.child(), EsRelation.class);
         assertThat(esRelation.indexPattern(), is("test_all"));
         assertTrue(esRelation.output().contains(fieldAttr));
@@ -1345,14 +1350,14 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         // Check the filter on the Count aggregate
         assertThat(count.filter(), equalTo(Literal.TRUE));
 
-        // Filter[$$dense_vector$DotProduct$26{f}#26 > 0.5[DOUBLE]]
+        // Filter[$$dense_vector$V_DOT_PRODUCT$26{f}#26 > 0.5[DOUBLE]]
         var filter = as(aggregate.child(), Filter.class);
         var filterCondition = as(filter.condition(), GreaterThan.class);
 
         // Check left side is the replaced field attribute
         var fieldAttr = as(filterCondition.left(), FieldAttribute.class);
         assertThat(fieldAttr.fieldName().string(), equalTo("dense_vector"));
-        assertThat(fieldAttr.name(), startsWith("$$dense_vector$DotProduct"));
+        assertThat(fieldAttr.name(), startsWith("$$dense_vector$V_DOT_PRODUCT$"));
         var field = as(fieldAttr.field(), FunctionEsField.class);
         var blockLoaderFunctionConfig = as(field.functionConfig(), DenseVectorFieldMapper.VectorSimilarityFunctionConfig.class);
         assertThat(blockLoaderFunctionConfig.similarityFunction(), is(DotProduct.SIMILARITY_FUNCTION));
@@ -1362,7 +1367,7 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         var filterFieldAttr = as(filterCondition.left(), FieldAttribute.class);
         assertThat(filterFieldAttr, is(fieldAttr));
 
-        // EsRelation[test_all][$$dense_vector$DotProduct$26{f}#26, !alias_integer, ..]
+        // EsRelation[test_all][$$dense_vector$V_DOT_PRODUCT$26{f}#26, !alias_integer, ..]
         var esRelation = as(filter.child(), EsRelation.class);
         assertTrue(esRelation.output().contains(filterFieldAttr));
     }
@@ -1395,7 +1400,7 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         // Check replaced field attribute
         var fieldAttr = as(alias.child(), FieldAttribute.class);
         assertThat(fieldAttr.fieldName().string(), equalTo("dense_vector"));
-        assertThat(fieldAttr.name(), startsWith("$$dense_vector$CosineSimilarity"));
+        assertThat(fieldAttr.name(), startsWith("$$dense_vector$V_COSINE$"));
         var field = as(fieldAttr.field(), FunctionEsField.class);
         var blockLoaderFunctionConfig = as(field.functionConfig(), DenseVectorFieldMapper.VectorSimilarityFunctionConfig.class);
         assertThat(blockLoaderFunctionConfig.similarityFunction(), is(CosineSimilarity.SIMILARITY_FUNCTION));
@@ -1411,10 +1416,10 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         assertTrue(
             innerProject.projections()
                 .stream()
-                .anyMatch(p -> (p instanceof FieldAttribute fa) && fa.name().startsWith("$$dense_vector$CosineSimilarity"))
+                .anyMatch(p -> (p instanceof FieldAttribute fa) && fa.name().startsWith("$$dense_vector$V_COSINE$"))
         );
 
-        // EsRelation[test_all][$$dense_vector$CosineSimilarity$33{f}#33, !alias_in..]
+        // EsRelation[test_all][$$dense_vector$V_COSINE$33{f}#33, !alias_in..]
         var esRelation = as(innerProject.child(), EsRelation.class);
         assertTrue(esRelation.output().contains(fieldAttr));
     }
@@ -1439,18 +1444,18 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         var eval = as(project.child(), Eval.class);
         assertThat(eval.fields(), hasSize(4));
 
-        // Check s1 = $$dense_vector$DotProduct$...
+        // Check s1 = $$dense_vector$V_DOT_PRODUCT$...
         var s1Alias = as(eval.fields().getFirst(), Alias.class);
         assertThat(s1Alias.name(), equalTo("s1"));
         var s1FieldAttr = as(s1Alias.child(), FieldAttribute.class);
         assertThat(s1FieldAttr.fieldName().string(), equalTo("dense_vector"));
-        assertThat(s1FieldAttr.name(), startsWith("$$dense_vector$DotProduct"));
+        assertThat(s1FieldAttr.name(), startsWith("$$dense_vector$V_DOT_PRODUCT$"));
         var s1Field = as(s1FieldAttr.field(), FunctionEsField.class);
         var s1Config = as(s1Field.functionConfig(), DenseVectorFieldMapper.VectorSimilarityFunctionConfig.class);
         assertThat(s1Config.similarityFunction(), is(DotProduct.SIMILARITY_FUNCTION));
         assertThat(s1Config.vector(), equalTo(new float[] { 1.0f, 2.0f, 3.0f }));
 
-        // Check s2 = $$dense_vector$DotProduct$1606418432 * 2 / 3 (same field as s1)
+        // Check s2 = $$dense_vector$V_DOT_PRODUCT$1606418432 * 2 / 3 (same field as s1)
         var s2Alias = as(eval.fields().get(1), Alias.class);
         assertThat(s2Alias.name(), equalTo("s2"));
         var s2Div = as(s2Alias.child(), Div.class);
@@ -1458,18 +1463,18 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         var s2FieldAttr = as(s2Mul.left(), FieldAttribute.class);
         assertThat(s1FieldAttr, is(s2FieldAttr));
 
-        // Check r1 = $$dense_vector$DotProduct$882900992 (vector [4.0, 5.0, 6.0])
+        // Check r1 = $$dense_vector$V_DOT_PRODUCT$882900992 (vector [4.0, 5.0, 6.0])
         var r1Alias = as(eval.fields().get(2), Alias.class);
         assertThat(r1Alias.name(), equalTo("r1"));
         var r1FieldAttr = as(r1Alias.child(), FieldAttribute.class);
         assertThat(r1FieldAttr.fieldName().string(), equalTo("dense_vector"));
-        assertThat(r1FieldAttr.name(), startsWith("$$dense_vector$DotProduct"));
+        assertThat(r1FieldAttr.name(), startsWith("$$dense_vector$V_DOT_PRODUCT$"));
         var r1Field = as(r1FieldAttr.field(), FunctionEsField.class);
         var r1Config = as(r1Field.functionConfig(), DenseVectorFieldMapper.VectorSimilarityFunctionConfig.class);
         assertThat(r1Config.similarityFunction(), is(DotProduct.SIMILARITY_FUNCTION));
         assertThat(r1Config.vector(), equalTo(new float[] { 4.0f, 5.0f, 6.0f }));
 
-        // Check r2 = $$dense_vector$DotProduct$882900992 + $$dense_vector$CosineSimilarity$882900992
+        // Check r2 = $$dense_vector$V_DOT_PRODUCT$882900992 + $$dense_vector$V_COSINE$882900992
         var r2Alias = as(eval.fields().get(3), Alias.class);
         assertThat(r2Alias.name(), equalTo("r2"));
         var r2Add = as(r2Alias.child(), Add.class);
@@ -1481,7 +1486,7 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         // Right side: CosineSimilarity field
         var r2CosineFieldAttr = as(r2Add.right(), FieldAttribute.class);
         assertThat(r2CosineFieldAttr.fieldName().string(), equalTo("dense_vector"));
-        assertThat(r2CosineFieldAttr.name(), startsWith("$$dense_vector$CosineSimilarity"));
+        assertThat(r2CosineFieldAttr.name(), startsWith("$$dense_vector$V_COSINE$"));
         var r2CosineField = as(r2CosineFieldAttr.field(), FunctionEsField.class);
         var r2CosineConfig = as(r2CosineField.functionConfig(), DenseVectorFieldMapper.VectorSimilarityFunctionConfig.class);
         assertThat(r2CosineConfig.similarityFunction(), is(CosineSimilarity.SIMILARITY_FUNCTION));
@@ -1495,6 +1500,217 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         assertTrue(esRelation.output().contains(s1FieldAttr));
         assertTrue(esRelation.output().contains(r1FieldAttr));
         assertTrue(esRelation.output().contains(r2CosineFieldAttr));
+    }
+
+    public void testLengthInEval() {
+        assumeTrue("requires similarity functions", EsqlCapabilities.Cap.VECTOR_SIMILARITY_FUNCTIONS_PUSHDOWN.isEnabled());
+        String query = """
+            FROM test
+            | EVAL l = LENGTH(last_name)
+            | KEEP l
+            """;
+        LogicalPlan plan = localPlan(plan(query, analyzer), TEST_SEARCH_STATS);
+
+        var project = as(plan, EsqlProject.class);
+        assertThat(Expressions.names(project.projections()), contains("l"));
+        var eval = as(project.child(), Eval.class);
+        Attribute lAttr = assertLengthPushdown(as(eval.fields().getFirst(), Alias.class).child(), "last_name");
+        var limit = as(eval.child(), Limit.class);
+        var relation = as(limit.child(), EsRelation.class);
+        assertTrue(relation.output().contains(lAttr));
+    }
+
+    public void testLengthInWhere() {
+        assumeTrue("requires similarity functions", EsqlCapabilities.Cap.VECTOR_SIMILARITY_FUNCTIONS_PUSHDOWN.isEnabled());
+        String query = """
+            FROM test
+            | WHERE LENGTH(last_name) > 1
+            """;
+        LogicalPlan plan = localPlan(plan(query, analyzer), TEST_SEARCH_STATS);
+
+        var project = as(plan, EsqlProject.class);
+        var limit = as(project.child(), Limit.class);
+        var filter = as(limit.child(), Filter.class);
+        Attribute lAttr = assertLengthPushdown(as(filter.condition(), GreaterThan.class).left(), "last_name");
+        var relation = as(filter.child(), EsRelation.class);
+        assertTrue(relation.output().contains(lAttr));
+    }
+
+    public void testLengthInStats() {
+        assumeTrue("requires 137382", EsqlCapabilities.Cap.VECTOR_SIMILARITY_FUNCTIONS_PUSHDOWN.isEnabled());
+        String query = """
+            FROM test
+            | STATS l = SUM(LENGTH(last_name))
+            """;
+        LogicalPlan plan = localPlan(plan(query, analyzer), TEST_SEARCH_STATS);
+
+        var limit = as(plan, Limit.class);
+        var agg = as(limit.child(), Aggregate.class);
+        assertThat(agg.aggregates(), hasSize(1));
+        as(as(agg.aggregates().getFirst(), Alias.class).child(), Sum.class);
+        var eval = as(agg.child(), Eval.class);
+        Attribute lAttr = assertLengthPushdown(as(eval.fields().getFirst(), Alias.class).child(), "last_name");
+        var relation = as(eval.child(), EsRelation.class);
+        assertTrue(relation.output().contains(lAttr));
+    }
+
+    public void testLengthInEvalAfterManyRenames() {
+        assumeTrue("requires push", EsqlCapabilities.Cap.VECTOR_SIMILARITY_FUNCTIONS_PUSHDOWN.isEnabled());
+        String query = """
+            FROM test
+            | EVAL l1 = last_name
+            | EVAL l2 = l1
+            | EVAL l3 = l2
+            | EVAL l = LENGTH(l3)
+            | KEEP l
+            """;
+        LogicalPlan plan = localPlan(plan(query, analyzer), TEST_SEARCH_STATS);
+
+        var project = as(plan, EsqlProject.class);
+        assertThat(Expressions.names(project.projections()), contains("l"));
+        var eval = as(project.child(), Eval.class);
+        Attribute lAttr = assertLengthPushdown(as(eval.fields().getFirst(), Alias.class).child(), "last_name");
+        var limit = as(eval.child(), Limit.class);
+        var relation = as(limit.child(), EsRelation.class);
+        assertTrue(relation.output().contains(lAttr));
+    }
+
+    public void testLengthInWhereAndEval() {
+        assumeFalse("fix me", true);
+        assumeTrue("requires push", EsqlCapabilities.Cap.VECTOR_SIMILARITY_FUNCTIONS_PUSHDOWN.isEnabled());
+        String query = """
+            FROM test
+            | WHERE LENGTH(last_name) > 1
+            | EVAL l = LENGTH(last_name)
+            """;
+        LogicalPlan plan = localPlan(plan(query, analyzer), TEST_SEARCH_STATS);
+
+        var project = as(plan, EsqlProject.class);
+        var limit = as(project.child(), Limit.class);
+        var eval = as(limit.child(), Eval.class);
+        var filter = as(eval.child(), Filter.class);
+        Attribute lAttr = assertLengthPushdown(as(filter.condition(), GreaterThan.class).left(), "last_name");
+        var relation = as(filter.child(), EsRelation.class);
+        assertThat(relation.output(), hasItem(lAttr));
+    }
+
+    /**
+     * Pushed LENGTH to the same field in a <strong>ton</strong> of unique and curious ways. All
+     * of these pushdowns should be fused to one.
+     */
+    public void testLengthPushdownZoo() {
+        assumeTrue("requires push", EsqlCapabilities.Cap.VECTOR_SIMILARITY_FUNCTIONS_PUSHDOWN.isEnabled());
+        String query = """
+            FROM test
+            | EVAL a1 = LENGTH(last_name), a2 = LENGTH(last_name), a3 = LENGTH(last_name),
+                   a4 = abs(LENGTH(last_name)) + a1 + LENGTH(first_name) * 3
+            | WHERE a1 > 1 and LENGTH(last_name) > 1
+            | STATS l = SUM(LENGTH(last_name)) + AVG(a3)
+            """;
+        LogicalPlan plan = localPlan(plan(query, analyzer), TEST_SEARCH_STATS);
+
+        var project = as(plan, Project.class);
+        var eval1 = as(project.child(), Eval.class); // SUM + AVG
+        var limit = as(eval1.child(), Limit.class);
+        var agg = as(limit.child(), Aggregate.class);
+        var eval2 = as(agg.child(), Eval.class); // Resolves the pushed LENGTH(last_name)
+        assertThat(eval2.fields(), hasSize(2));
+
+        Alias a3 = as(eval2.fields().getFirst(), Alias.class);
+        assertThat(a3.name(), equalTo("a3"));
+        Attribute a3Push = assertLengthPushdown(a3.child(), "last_name");
+
+        Alias sumInput = as(eval2.fields().getFirst(), Alias.class);
+        Attribute sumInputPush = assertLengthPushdown(sumInput.child(), "last_name");
+
+        Filter filter = as(eval2.child(), Filter.class);
+        And and = as(filter.condition(), And.class);
+        GreaterThan left = as(and.left(), GreaterThan.class);
+        Expression a1 = left.left();
+        Attribute a1Push = assertLengthPushdown(a1, "last_name");
+
+        GreaterThan right = as(and.right(), GreaterThan.class);
+        Attribute filterPush = assertLengthPushdown(right.left(), "last_name");
+
+        EsRelation relation = as(filter.child(), EsRelation.class);
+        assertThat(relation.output(), hasItems(a3Push, sumInputPush, a1Push, filterPush));
+
+        assertThat(relation.output().stream().filter(a -> {
+            if (a instanceof FieldAttribute fa) {
+                if (fa.field() instanceof FunctionEsField fef) {
+                    return fef.functionConfig().function() == BlockLoaderFunctionConfig.Function.LENGTH;
+                }
+            }
+            return false;
+        }).toList(),
+            hasSize(
+                4 // Should be 1 - fix in https://github.com/elastic/elasticsearch/issues/137679
+            )
+        );
+    }
+
+    public void testLengthInStatsTwice() {
+        assumeTrue("requires push", EsqlCapabilities.Cap.VECTOR_SIMILARITY_FUNCTIONS_PUSHDOWN.isEnabled());
+        String query = """
+            FROM test
+            | STATS l = SUM(LENGTH(last_name)) + AVG(LENGTH(last_name))
+            """;
+        LogicalPlan plan = localPlan(plan(query, analyzer), TEST_SEARCH_STATS);
+
+        var project = as(plan, Project.class);
+        var eval1 = as(project.child(), Eval.class);
+        var limit = as(eval1.child(), Limit.class);
+        var agg = as(limit.child(), Aggregate.class);
+        assertThat(agg.aggregates(), hasSize(2));
+        var sum = as(as(agg.aggregates().getFirst(), Alias.class).child(), Sum.class);
+        var count = as(as(agg.aggregates().get(1), Alias.class).child(), Count.class);
+        var eval2 = as(agg.child(), Eval.class);
+        assertThat(eval2.fields(), hasSize(1));
+        Alias lAlias = as(eval2.fields().getFirst(), Alias.class);
+        Attribute lAttr = assertLengthPushdown(lAlias.child(), "last_name");
+        var relation = as(eval2.child(), EsRelation.class);
+        assertTrue(relation.output().contains(lAttr));
+
+        assertThat(as(sum.field(), ReferenceAttribute.class).id(), equalTo(lAlias.id()));
+        assertThat(as(count.field(), ReferenceAttribute.class).id(), equalTo(lAlias.id()));
+    }
+
+    public void testLengthTwoFields() {
+        assumeTrue("requires push", EsqlCapabilities.Cap.VECTOR_SIMILARITY_FUNCTIONS_PUSHDOWN.isEnabled());
+        String query = """
+            FROM test
+            | STATS last_name = SUM(LENGTH(last_name)), first_name = SUM(LENGTH(first_name))
+            """;
+        LogicalPlan plan = localPlan(plan(query, analyzer), TEST_SEARCH_STATS);
+
+        var limit = as(plan, Limit.class);
+        var agg = as(limit.child(), Aggregate.class);
+        assertThat(agg.aggregates(), hasSize(2));
+        var sum1 = as(as(agg.aggregates().getFirst(), Alias.class).child(), Sum.class);
+        var sum2 = as(as(agg.aggregates().get(1), Alias.class).child(), Sum.class);
+        var eval = as(agg.child(), Eval.class);
+
+        assertThat(eval.fields(), hasSize(2));
+        Alias lastNameAlias = as(eval.fields().getFirst(), Alias.class);
+        Attribute lastNameAttr = assertLengthPushdown(lastNameAlias.child(), "last_name");
+        Alias firstNameAlias = as(eval.fields().get(1), Alias.class);
+        Attribute firstNameAttr = assertLengthPushdown(firstNameAlias.child(), "first_name");
+
+        var relation = as(eval.child(), EsRelation.class);
+        assertThat(relation.output(), hasItems(lastNameAttr, firstNameAttr));
+
+        assertThat(as(sum1.field(), ReferenceAttribute.class).id(), equalTo(lastNameAlias.id()));
+        assertThat(as(sum2.field(), ReferenceAttribute.class).id(), equalTo(firstNameAlias.id()));
+    }
+
+    private Attribute assertLengthPushdown(Expression e, String fieldName) {
+        FieldAttribute attr = as(e, FieldAttribute.class);
+        assertThat(attr.name(), startsWith("$$" + fieldName + "$LENGTH$"));
+        var field = as(attr.field(), FunctionEsField.class);
+        assertThat(field.functionConfig().function(), is(BlockLoaderFunctionConfig.Function.LENGTH));
+        assertThat(field.getName(), equalTo(fieldName));
+        assertThat(field.getExactInfo().hasExact(), equalTo(false));
+        return attr;
     }
 
     public void testFullTextFunctionOnMissingField() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/ConstantShardContextIndexedByShardId.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/ConstantShardContextIndexedByShardId.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.lucene.IndexedByShardId;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.SourceLoader;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.sort.SortAndFormats;
 import org.elasticsearch.search.sort.SortBuilder;
@@ -70,7 +71,7 @@ public class ConstantShardContextIndexedByShardId implements IndexedByShardId<Es
             String name,
             boolean asUnsupportedSource,
             MappedFieldType.FieldExtractPreference fieldExtractPreference,
-            MappedFieldType.BlockLoaderFunctionConfig blockLoaderFunctionConfig
+            BlockLoaderFunctionConfig blockLoaderFunctionConfig
         ) {
             throw new UnsupportedOperationException();
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/DisabledSearchStats.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/DisabledSearchStats.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.esql.stats;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute.FieldName;
 
 public class DisabledSearchStats implements SearchStats {
@@ -25,12 +27,22 @@ public class DisabledSearchStats implements SearchStats {
 
     @Override
     public boolean hasDocValues(FieldName field) {
-        return true;
+        // Some geo tests assume doc values and the loader emulates it. Nothing else does.
+        return field.string().endsWith("location") || field.string().endsWith("centroid") || field.string().equals("subset");
     }
 
     @Override
     public boolean hasExactSubfield(FieldName field) {
         return true;
+    }
+
+    @Override
+    public boolean supportsLoaderConfig(
+        FieldName name,
+        BlockLoaderFunctionConfig config,
+        MappedFieldType.FieldExtractPreference preference
+    ) {
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/FunctionEsFieldTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/FunctionEsFieldTests.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.xpack.esql.type;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
@@ -34,7 +34,7 @@ public class FunctionEsFieldTests extends AbstractEsFieldTypeTests<FunctionEsFie
     protected FunctionEsField mutateInstance(FunctionEsField instance) throws IOException {
         EsField esField = instance.getExactField();
         DataType dataType = instance.getDataType();
-        MappedFieldType.BlockLoaderFunctionConfig functionConfig = instance.functionConfig();
+        BlockLoaderFunctionConfig functionConfig = instance.functionConfig();
         switch (between(0, 2)) {
             case 0 -> esField = randomValueOtherThan(esField, () -> randomAnyEsField(4));
             case 1 -> dataType = randomValueOtherThan(dataType, () -> randomFrom(DataType.types()));


### PR DESCRIPTION
Speeds up queries like
```
FROM foo
| STATS SUM(LENGTH(field))
```
by fusing the `LENGTH` into the loading of the `field` if it has doc values. Running a fairly simple test:
https://gist.github.com/nik9000/9dac067f8ce29875a4fb0f0359a75091 I'm seeing that query drop from 48ms to 28ms. So, like, 40% faster.

More importantly, this makes the mechanism for fusing functions into field loading generic. All you have to do is implement `BlockLoaderExpression` on your expression and return non-null from `tryFuse`.