### PR TITLE
Mirror upstream elastic/elasticsearch#137274 for AI review (snapshot of HEAD tree)

### DIFF
--- a/docs/changelog/137274.yaml
+++ b/docs/changelog/137274.yaml
@@ -1,0 +1,5 @@
+pr: 137274
+summary: Use a new synthetic `_id` format for time-series datastreams
+area: TSDB
+type: enhancement
+issues: []

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBSyntheticIdsIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBSyntheticIdsIT.java
@@ -22,28 +22,35 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.IdFieldMapper;
+import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Random;
 
 import static org.elasticsearch.common.time.FormatNames.STRICT_DATE_OPTIONAL_TIME;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertCheckedResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -94,54 +101,59 @@ public class TSDBSyntheticIdsIT extends ESIntegTestCase {
         );
     }
 
-    @TestLogging(reason = "debug", value = "org.elasticsearch.index.engine.Engine:TRACE")
     public void testSyntheticId() throws Exception {
         assumeTrue("Test should only run with feature flag", IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG);
-        final var indexName = randomIdentifier();
-        putDataStreamTemplate(random(), indexName);
+        final var dataStreamName = randomIdentifier();
+        putDataStreamTemplate(dataStreamName, randomIntBetween(1, 5));
 
+        final var docs = new HashMap<String, String>();
+        final var unit = randomFrom(ChronoUnit.SECONDS, ChronoUnit.MINUTES);
         final var timestamp = Instant.now();
+        logger.info("timestamp is " + timestamp);
 
-        // Index 5 docs in datastream
+        // Index 10 docs in datastream
+        //
+        // For convenience, the metric value maps the index in the bulk response items
         var results = createDocuments(
-            indexName,
-            document(timestamp, "vm-dev01", "cpu-load", 0),                                // will be updated
-            document(timestamp.plusSeconds(2), "vm-dev01", "cpu-load", 1),    // will be deleted
-            document(timestamp, "vm-dev02", "cpu-load", 2),
-            document(timestamp.plusSeconds(2), "vm-dev03", "cpu-load", 3),
-            document(timestamp.plusSeconds(3), "vm-dev03", "cpu-load", 4)
+            dataStreamName,
+            // t + 0s
+            document(timestamp, "vm-dev01", "cpu-load", 0),
+            document(timestamp, "vm-dev02", "cpu-load", 1),
+            // t + 1s
+            document(timestamp.plus(1, unit), "vm-dev01", "cpu-load", 2),
+            document(timestamp.plus(1, unit), "vm-dev02", "cpu-load", 3),
+            // t + 0s out-of-order doc
+            document(timestamp, "vm-dev03", "cpu-load", 4),
+            // t + 2s
+            document(timestamp.plus(2, unit), "vm-dev01", "cpu-load", 5),
+            document(timestamp.plus(2, unit), "vm-dev02", "cpu-load", 6),
+            // t - 1s out-of-order doc
+            document(timestamp.minus(1, unit), "vm-dev01", "cpu-load", 7),
+            // t + 3s
+            document(timestamp.plus(3, unit), "vm-dev01", "cpu-load", 8),
+            document(timestamp.plus(3, unit), "vm-dev02", "cpu-load", 9)
         );
 
-        // Verify documents
-        assertThat(results[0].getResponse().getResult(), equalTo(DocWriteResponse.Result.CREATED));
-        assertThat(results[0].getVersion(), equalTo(1L));
-
-        assertThat(results[1].getResponse().getResult(), equalTo(DocWriteResponse.Result.CREATED));
-        assertThat(results[1].getVersion(), equalTo(1L));
-
-        assertThat(results[2].getResponse().getResult(), equalTo(DocWriteResponse.Result.CREATED));
-        assertThat(results[2].getVersion(), equalTo(1L));
-
-        assertThat(results[3].getResponse().getResult(), equalTo(DocWriteResponse.Result.CREATED));
-        assertThat(results[3].getVersion(), equalTo(1L));
-
-        assertThat(results[4].getResponse().getResult(), equalTo(DocWriteResponse.Result.CREATED));
-        assertThat(results[4].getVersion(), equalTo(1L));
-
-        final var docIndex = results[1].getIndex();
-        final var docId = results[1].getId();
+        // Verify that documents are created
+        for (var result : results) {
+            assertThat(result.getResponse().getResult(), equalTo(DocWriteResponse.Result.CREATED));
+            assertThat(result.getVersion(), equalTo(1L));
+            docs.put(result.getId(), result.getIndex());
+        }
 
         enum Operation {
             FLUSH,
             REFRESH,
             NONE
         }
+
+        // Random flush or refresh or nothing, so that the next GETs are executed on flushed segments or in memory segments.
         switch (randomFrom(Operation.values())) {
             case FLUSH:
-                flush(indexName);
+                flush(dataStreamName);
                 break;
             case REFRESH:
-                refresh(indexName);
+                refresh(dataStreamName);
                 break;
             case NONE:
             default:
@@ -149,46 +161,225 @@ public class TSDBSyntheticIdsIT extends ESIntegTestCase {
         }
 
         // Get by synthetic _id
-        // Note: before synthetic _id this would have required postings on disks
-        var getResponse = client().prepareGet(docIndex, docId).setFetchSource(true).execute().actionGet();
-        assertThat(getResponse.isExists(), equalTo(true));
-        assertThat(getResponse.getVersion(), equalTo(1L));
-        var source = asInstanceOf(Map.class, getResponse.getSourceAsMap().get("metric"));
-        assertThat(asInstanceOf(Integer.class, source.get("value")), equalTo(1));
+        var randomDocs = randomSubsetOf(randomIntBetween(0, results.length), results);
+        for (var doc : randomDocs) {
+            boolean fetchSource = randomBoolean();
+            var getResponse = client().prepareGet(doc.getIndex(), doc.getId()).setFetchSource(fetchSource).get();
+            assertThat(getResponse.isExists(), equalTo(true));
+            assertThat(getResponse.getVersion(), equalTo(1L));
 
-        // Update by synthetic _id
-        // Note: it doesn't work, is that expected? Is is blocked by IndexRouting.ExtractFromSource.updateShard
-        var exception = expectThrows(IllegalArgumentException.class, () -> {
-            var doc = document(timestamp, "vm-dev01", "cpu-load", 10); // update
-            client().prepareUpdate(docIndex, docId).setDoc(doc).get();
-        });
-        assertThat(
-            exception.getMessage(),
-            containsString("update is not supported because the destination index [" + docIndex + "] is in time_series mode")
-        );
+            if (fetchSource) {
+                var source = asInstanceOf(Map.class, getResponse.getSourceAsMap().get("metric"));
+                assertThat(asInstanceOf(Integer.class, source.get("value")), equalTo(doc.getItemId()));
+            }
+        }
+
+        // Random flush or refresh or nothing, so that the next DELETEs are executed on flushed segments or in memory segments.
+        switch (randomFrom(Operation.values())) {
+            case FLUSH:
+                flush(dataStreamName);
+                break;
+            case REFRESH:
+                refresh(dataStreamName);
+                break;
+            case NONE:
+            default:
+                break;
+        }
 
         // Delete by synthetic _id
-        var deleteResponse = client().prepareDelete(docIndex, docId).get();
-        assertThat(deleteResponse.getId(), equalTo(docId));
-        assertThat(deleteResponse.getResult(), equalTo(DocWriteResponse.Result.DELETED));
-        assertThat(deleteResponse.getVersion(), equalTo(2L));
+        var deletedDocs = randomSubsetOf(randomIntBetween(1, docs.size()), docs.keySet());
+        for (var docId : deletedDocs) {
+            var deletedDocIndex = docs.get(docId);
+            assertThat(deletedDocIndex, notNullValue());
 
-        // Index more docs
-        // TODO Randomize this to have segments only composed of deleted docs
-        createDocuments(
-            indexName,
-            document(timestamp.plusSeconds(4), "vm-dev03", "cpu-load", 5),
-            document(timestamp.plusSeconds(5), "vm-dev03", "cpu-load", 6)
+            // Delete
+            var deleteResponse = client().prepareDelete(deletedDocIndex, docId).get();
+            assertThat(deleteResponse.getId(), equalTo(docId));
+            assertThat(deleteResponse.getIndex(), equalTo(deletedDocIndex));
+            assertThat(deleteResponse.getResult(), equalTo(DocWriteResponse.Result.DELETED));
+            assertThat(deleteResponse.getVersion(), equalTo(2L));
+        }
+
+        // Index more random docs
+        if (randomBoolean()) {
+            int nbDocs = randomIntBetween(1, 100);
+            final var arrayOfDocs = new XContentBuilder[nbDocs];
+
+            var t = timestamp.plus(4, unit); // t + 4s, no overlap with previous docs
+            while (nbDocs > 0) {
+                var hosts = randomSubsetOf(List.of("vm-dev01", "vm-dev02", "vm-dev03"));
+                for (var host : hosts) {
+                    if (--nbDocs < 0) {
+                        break;
+                    }
+                    arrayOfDocs[nbDocs] = document(t, host, "cpu-load", randomInt(10));
+                }
+                // always use seconds, otherwise the doc might fell outside of the timestamps window of the datastream
+                t = t.plus(1, ChronoUnit.SECONDS);
+            }
+
+            results = createDocuments(dataStreamName, arrayOfDocs);
+
+            // Verify that documents are created
+            for (var result : results) {
+                assertThat(result.getResponse().getResult(), equalTo(DocWriteResponse.Result.CREATED));
+                assertThat(result.getVersion(), equalTo(1L));
+                docs.put(result.getId(), result.getIndex());
+            }
+        }
+
+        refresh(dataStreamName);
+
+        assertCheckedResponse(client().prepareSearch(dataStreamName).setTrackTotalHits(true).setSize(100), searchResponse -> {
+            assertHitCount(searchResponse, docs.size() - deletedDocs.size());
+
+            // Verify that search response does not contain deleted docs
+            for (var searchHit : searchResponse.getHits()) {
+                assertThat(
+                    "Document with id [" + searchHit.getId() + "] is deleted",
+                    deletedDocs.contains(searchHit.getId()),
+                    equalTo(false)
+                );
+            }
+        });
+
+        // Search by synthetic _id
+        var otherDocs = randomSubsetOf(Sets.difference(docs.keySet(), Sets.newHashSet(deletedDocs)));
+        for (var docId : otherDocs) {
+            assertCheckedResponse(
+                client().prepareSearch(docs.get(docId))
+                    .setSource(new SearchSourceBuilder().query(new TermQueryBuilder(IdFieldMapper.NAME, docId))),
+                searchResponse -> {
+                    assertHitCount(searchResponse, 1L);
+                    assertThat(searchResponse.getHits().getHits(), arrayWithSize(1));
+                    assertThat(searchResponse.getHits().getHits()[0].getId(), equalTo(docId));
+                }
+            );
+        }
+
+        flush(dataStreamName);
+
+        // Check that synthetic _id field have no postings on disk
+        var indices = new HashSet<>(docs.values());
+        for (var index : indices) {
+            var diskUsage = diskUsage(index);
+            var diskUsageIdField = AnalyzeIndexDiskUsageTestUtils.getPerFieldDiskUsage(diskUsage, IdFieldMapper.NAME);
+            assertThat("_id field should not have postings on disk", diskUsageIdField.getInvertedIndexBytes(), equalTo(0L));
+        }
+    }
+
+    public void testGetFromTranslogBySyntheticId() throws Exception {
+        assumeTrue("Test should only run with feature flag", IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG);
+        final var dataStreamName = randomIdentifier();
+        putDataStreamTemplate(dataStreamName, 1);
+
+        final var docs = new HashMap<String, String>();
+        final var unit = randomFrom(ChronoUnit.SECONDS, ChronoUnit.MINUTES);
+        final var timestamp = Instant.now();
+
+        // Index 5 docs in datastream
+        //
+        // For convenience, the metric value maps the index in the bulk response items
+        var results = createDocuments(
+            dataStreamName,
+            // t + 0s
+            document(timestamp, "vm-dev01", "cpu-load", 0),
+            document(timestamp, "vm-dev02", "cpu-load", 1),
+            // t + 1s
+            document(timestamp.plus(1, unit), "vm-dev01", "cpu-load", 2),
+            document(timestamp.plus(1, unit), "vm-dev02", "cpu-load", 3),
+            // t + 0s out-of-order doc
+            document(timestamp, "vm-dev03", "cpu-load", 4)
         );
 
-        flushAndRefresh(indexName);
+        // Verify that documents are created
+        for (var result : results) {
+            assertThat(result.getResponse().getResult(), equalTo(DocWriteResponse.Result.CREATED));
+            assertThat(result.getVersion(), equalTo(1L));
+            docs.put(result.getId(), result.getIndex());
+        }
 
-        // Check that synthetic _id field has no postings on disk
-        var diskUsage = diskUsage(docIndex);
-        var diskUsageIdField = AnalyzeIndexDiskUsageTestUtils.getPerFieldDiskUsage(diskUsage, IdFieldMapper.NAME);
-        assertThat("_id field should not have postings on disk", diskUsageIdField.getInvertedIndexBytes(), equalTo(0L));
+        // Get by synthetic _id
+        //
+        // The documents are in memory buffers: the first GET will trigger the refresh of the internal reader
+        // (see InternalEngine.REAL_TIME_GET_REFRESH_SOURCE) to have an up-to-date searcher to resolve documents ids and versions. It will
+        // also enable the tracking of the locations of documents in the translog (see InternalEngine.trackTranslogLocation) so that next
+        // GETs will be resolved using the translog.
+        var randomDocs = randomSubsetOf(randomIntBetween(1, results.length), results);
+        for (var doc : randomDocs) {
+            var getResponse = client().prepareGet(doc.getIndex(), doc.getId()).setRealtime(true).setFetchSource(true).execute().actionGet();
+            assertThat(getResponse.isExists(), equalTo(true));
+            assertThat(getResponse.getVersion(), equalTo(1L));
 
-        // TODO Search datastream and count hits
+            var source = asInstanceOf(Map.class, getResponse.getSourceAsMap().get("metric"));
+            assertThat(asInstanceOf(Integer.class, source.get("value")), equalTo(doc.getItemId()));
+        }
+
+        int metricOffset = results.length;
+
+        // Index 5 more docs
+        results = createDocuments(
+            dataStreamName,
+            // t + 2s
+            document(timestamp.plus(2, unit), "vm-dev01", "cpu-load", metricOffset),
+            document(timestamp.plus(2, unit), "vm-dev02", "cpu-load", metricOffset + 1),
+            // t - 1s out-of-order doc
+            document(timestamp.minus(1, unit), "vm-dev01", "cpu-load", metricOffset + 2),
+            // t + 3s
+            document(timestamp.plus(3, unit), "vm-dev01", "cpu-load", metricOffset + 3),
+            document(timestamp.plus(3, unit), "vm-dev02", "cpu-load", metricOffset + 4)
+        );
+
+        // Verify that documents are created
+        for (var result : results) {
+            assertThat(result.getResponse().getResult(), equalTo(DocWriteResponse.Result.CREATED));
+            assertThat(result.getVersion(), equalTo(1L));
+            docs.put(result.getId(), result.getIndex());
+        }
+
+        // Get by synthetic _id
+        //
+        // Documents ids and versions are resolved using the translog. Here we exercise the get-from-translog (that uses the
+        // TranslogDirectoryReader) and VersionsAndSeqNoResolver.loadDocIdAndVersionUncached paths.
+        randomDocs = randomSubsetOf(randomIntBetween(1, results.length), results);
+        for (var doc : randomDocs) {
+            var getResponse = client().prepareGet(doc.getIndex(), doc.getId()).setRealtime(true).setFetchSource(true).execute().actionGet();
+            assertThat(getResponse.isExists(), equalTo(true));
+            assertThat(getResponse.getVersion(), equalTo(1L));
+
+            var source = asInstanceOf(Map.class, getResponse.getSourceAsMap().get("metric"));
+            assertThat(asInstanceOf(Integer.class, source.get("value")), equalTo(metricOffset + doc.getItemId()));
+        }
+
+        flushAndRefresh(dataStreamName);
+
+        // Get by synthetic _id
+        //
+        // Here we exercise the get-from-searcher and VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion paths.
+        randomDocs = randomSubsetOf(randomIntBetween(1, results.length), results);
+        for (var doc : randomDocs) {
+            var getResponse = client().prepareGet(doc.getIndex(), doc.getId())
+                .setRealtime(randomBoolean())
+                .setFetchSource(true)
+                .execute()
+                .actionGet();
+            assertThat(getResponse.isExists(), equalTo(true));
+            assertThat(getResponse.getVersion(), equalTo(1L));
+
+            var source = asInstanceOf(Map.class, getResponse.getSourceAsMap().get("metric"));
+            assertThat(asInstanceOf(Integer.class, source.get("value")), equalTo(metricOffset + doc.getItemId()));
+        }
+
+        // Check that synthetic _id field have no postings on disk
+        var indices = new HashSet<>(docs.values());
+        for (var index : indices) {
+            var diskUsage = diskUsage(index);
+            var diskUsageIdField = AnalyzeIndexDiskUsageTestUtils.getPerFieldDiskUsage(diskUsage, IdFieldMapper.NAME);
+            assertThat("_id field should not have postings on disk", diskUsageIdField.getInvertedIndexBytes(), equalTo(0L));
+        }
+
+        assertHitCount(client().prepareSearch(dataStreamName).setSize(0), 10L);
     }
 
     private static XContentBuilder document(Instant timestamp, String hostName, String metricField, Integer metricValue)
@@ -210,7 +401,7 @@ public class TSDBSyntheticIdsIT extends ESIntegTestCase {
         return source;
     }
 
-    private static BulkItemResponse[] createDocuments(String indexName, XContentBuilder... docs) throws IOException {
+    private static BulkItemResponse[] createDocuments(String indexName, XContentBuilder... docs) {
         assertThat(docs, notNullValue());
         final var client = client();
         var bulkRequest = client.prepareBulk();
@@ -222,8 +413,8 @@ public class TSDBSyntheticIdsIT extends ESIntegTestCase {
         return bulkResponse.getItems();
     }
 
-    private static void putDataStreamTemplate(Random random, String indexPattern) throws IOException {
-        final var settings = indexSettings(1, 0).put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
+    private static void putDataStreamTemplate(String indexPattern, int shards) throws IOException {
+        final var settings = indexSettings(shards, 0).put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
             .put(IndexSettings.BLOOM_FILTER_ID_FIELD_ENABLED_SETTING.getKey(), false)
             .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), -1)
             .put(IndexSettings.USE_SYNTHETIC_ID.getKey(), true);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -705,6 +705,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     @Nullable
     private final IndexReshardingMetadata reshardingMetadata;
 
+    private final boolean useTimeSeriesSyntheticId;
+
     private IndexMetadata(
         final Index index,
         final long version,
@@ -754,7 +756,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         @Nullable final IndexMetadataStats stats,
         @Nullable final Double writeLoadForecast,
         @Nullable Long shardSizeInBytesForecast,
-        @Nullable IndexReshardingMetadata reshardingMetadata
+        @Nullable IndexReshardingMetadata reshardingMetadata,
+        final boolean useTimeSeriesSyntheticId
     ) {
         this.index = index;
         this.version = version;
@@ -815,6 +818,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         this.shardSizeInBytesForecast = shardSizeInBytesForecast;
         assert numberOfShards * routingFactor == routingNumShards : routingNumShards + " must be a multiple of " + numberOfShards;
         this.reshardingMetadata = reshardingMetadata;
+        this.useTimeSeriesSyntheticId = useTimeSeriesSyntheticId;
     }
 
     IndexMetadata withMappingMetadata(MappingMetadata mapping) {
@@ -870,7 +874,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.stats,
             this.writeLoadForecast,
             this.shardSizeInBytesForecast,
-            this.reshardingMetadata
+            this.reshardingMetadata,
+            this.useTimeSeriesSyntheticId
         );
     }
 
@@ -933,7 +938,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.stats,
             this.writeLoadForecast,
             this.shardSizeInBytesForecast,
-            this.reshardingMetadata
+            this.reshardingMetadata,
+            this.useTimeSeriesSyntheticId
         );
     }
 
@@ -1004,7 +1010,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.stats,
             this.writeLoadForecast,
             this.shardSizeInBytesForecast,
-            this.reshardingMetadata
+            this.reshardingMetadata,
+            this.useTimeSeriesSyntheticId
         );
     }
 
@@ -1066,7 +1073,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.stats,
             this.writeLoadForecast,
             this.shardSizeInBytesForecast,
-            this.reshardingMetadata
+            this.reshardingMetadata,
+            this.useTimeSeriesSyntheticId
         );
     }
 
@@ -1123,7 +1131,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.stats,
             this.writeLoadForecast,
             this.shardSizeInBytesForecast,
-            this.reshardingMetadata
+            this.reshardingMetadata,
+            this.useTimeSeriesSyntheticId
         );
     }
 
@@ -1312,6 +1321,13 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     @Nullable
     public Instant getTimeSeriesEnd() {
         return timeSeriesEnd;
+    }
+
+    /**
+     * @return whether the index is a time-series index that uses synthetic ids or not.
+     */
+    public boolean useTimeSeriesSyntheticId() {
+        return useTimeSeriesSyntheticId;
     }
 
     /**
@@ -2497,6 +2513,16 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             String indexModeString = settings.get(IndexSettings.MODE.getKey());
             final IndexMode indexMode = indexModeString != null ? IndexMode.fromString(indexModeString.toLowerCase(Locale.ROOT)) : null;
             final boolean isTsdb = indexMode == IndexMode.TIME_SERIES;
+            boolean useTimeSeriesSyntheticId = false;
+            if (isTsdb
+                && IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG
+                && indexCreatedVersion.onOrAfter(IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID)) {
+                var setting = settings.get(IndexSettings.USE_SYNTHETIC_ID.getKey());
+                if (setting != null && setting.equalsIgnoreCase(Boolean.TRUE.toString())) {
+                    assert IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG;
+                    useTimeSeriesSyntheticId = true;
+                }
+            }
             return new IndexMetadata(
                 new Index(index, uuid),
                 version,
@@ -2546,7 +2572,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 stats,
                 indexWriteLoadForecast,
                 shardSizeInBytesForecast,
-                reshardingMetadata
+                reshardingMetadata,
+                useTimeSeriesSyntheticId
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -192,6 +192,7 @@ public class IndexVersions {
 
     public static final IndexVersion REENABLED_TIMESTAMP_DOC_VALUES_SPARSE_INDEX = def(9_042_0_00, Version.LUCENE_10_3_1);
     public static final IndexVersion SKIPPERS_ENABLED_BY_DEFAULT = def(9_043_0_00, Version.LUCENE_10_3_1);
+    public static final IndexVersion TIME_SERIES_USE_SYNTHETIC_ID = def(9_044_0_00, Version.LUCENE_10_3_1);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
@@ -67,7 +67,7 @@ public class CodecService implements CodecProvider {
         for (String codec : Codec.availableCodecs()) {
             codecs.put(codec, Codec.forName(codec));
         }
-        final boolean useTsdbSyntheticId = mapperService != null && mapperService.getIndexSettings().useTsdbSyntheticId();
+        final boolean useTsdbSyntheticId = mapperService != null && mapperService.getIndexSettings().useTimeSeriesSyntheticId();
         assert useTsdbSyntheticId == false || mapperService.getIndexSettings().getMode() == IndexMode.TIME_SERIES;
 
         this.codecs = codecs.entrySet().stream().collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdFieldsProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdFieldsProducer.java
@@ -12,6 +12,7 @@ package org.elasticsearch.index.codec.tsdb;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.index.BaseTermsEnum;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.ImpactsEnum;
 import org.apache.lucene.index.PostingsEnum;
@@ -28,7 +29,6 @@ import org.elasticsearch.index.mapper.TsidExtractingIdFieldMapper;
 import org.elasticsearch.index.mapper.Uid;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
@@ -37,6 +37,10 @@ import static org.elasticsearch.index.codec.tsdb.TSDBSyntheticIdPostingsFormat.S
 import static org.elasticsearch.index.codec.tsdb.TSDBSyntheticIdPostingsFormat.TIMESTAMP;
 import static org.elasticsearch.index.codec.tsdb.TSDBSyntheticIdPostingsFormat.TS_ID;
 
+/**
+ * Produces synthetic _id terms that are computed at runtime from the doc values of other fields like _tsid, @timestamp and
+ * _ts_routing_hash.
+ */
 public class TSDBSyntheticIdFieldsProducer extends FieldsProducer {
 
     private static final Set<String> FIELDS_NAMES = Set.of(SYNTHETIC_ID);
@@ -85,7 +89,7 @@ public class TSDBSyntheticIdFieldsProducer extends FieldsProducer {
         return new Terms() {
             @Override
             public TermsEnum iterator() {
-                return new FakeTermsEnum();
+                return new SyntheticIdTermsEnum();
             }
 
             @Override
@@ -131,97 +135,371 @@ public class TSDBSyntheticIdFieldsProducer extends FieldsProducer {
     }
 
     /**
-     * This is a fake TermsEnum that scans all documents for find docs matching a specific _id. This implementation is only here to show
-     * that the synthetic _id terms is used when applying doc values updates during soft-updates. It is buggy and should not be used besides
-     * some carefully crafted integration tests, because it relies on the current _id format for TSDB indices that has limitations:
-     * - it is composed of a routing hash, a @timestamp and a tsid that cannot be un-hashed so all docs must be scanned to find matchings
-     * - it is not sorted on _id in the Lucene segments so doc values updates stop too early when applying DV updates
-     *
-     * This fake terms enumeration will be changed to support a different _id format in a short future.
+     * Holds all the doc values used in the {@link TermsEnum} and {@link PostingsEnum} to lookup and to build synthetic _ids, along with
+     * some utility methods to access doc values.
+     * <p>
+     *     It holds the instance of {@link DocValuesProducer} used to create the sorted doc values for _tsid, @timestamp and
+     *     _ts_routing_hash. Because doc values can only advance, they are re-created from the {@link DocValuesProducer} when we need to
+     *     seek backward.
+     * </p>
      */
-    private class FakeTermsEnum extends BaseTermsEnum {
+    private static class DocValuesHolder {
 
-        private BytesRef term = null;
-        private int docID = -1;
+        private final FieldInfo tsIdFieldInfo;
+        private final FieldInfo timestampFieldInfo;
+        private final FieldInfo routingHashFieldInfo;
+        private final DocValuesProducer docValuesProducer;
 
-        private BytesRef latestTsId = null;
-        private long latestTimestamp = -1L;
+        private SortedNumericDocValues timestampDocValues; // sorted desc. order
+        private SortedDocValues routingHashDocValues; // sorted asc. order
+        private SortedDocValues tsIdDocValues; // sorted asc. order
+        // Keep around the latest tsId ordinal and value
+        private int cachedTsIdOrd = -1;
+        private BytesRef cachedTsId;
 
-        private FakeTermsEnum() {}
+        private DocValuesHolder(FieldInfos fieldInfos, DocValuesProducer docValuesProducer) {
+            this.tsIdFieldInfo = safeFieldInfo(fieldInfos, TSDBSyntheticIdPostingsFormat.TS_ID);
+            this.timestampFieldInfo = safeFieldInfo(fieldInfos, TSDBSyntheticIdPostingsFormat.TIMESTAMP);
+            this.routingHashFieldInfo = safeFieldInfo(fieldInfos, TSDBSyntheticIdPostingsFormat.TS_ROUTING_HASH);
+            this.docValuesProducer = docValuesProducer;
+        }
 
-        @Override
-        public BytesRef next() throws IOException {
-            if (docID == DocIdSetIterator.NO_MORE_DOCS) {
-                assert term == null;
-                return null;
+        private FieldInfo safeFieldInfo(FieldInfos fieldInfos, String fieldName) {
+            var fi = fieldInfos.fieldInfo(fieldName);
+            if (fi == null) {
+                var message = "Field [" + fieldName + "] does not exist";
+                assert false : message;
+                throw new IllegalArgumentException(message);
             }
-            docID += 1;
-            if (maxDocs <= docID) {
-                docID = DocIdSetIterator.NO_MORE_DOCS;
-                latestTimestamp = -1L;
-                latestTsId = null;
-                term = null;
-                return null;
-            }
+            return fi;
+        }
 
-            // Retrieve _tsid
-            SortedDocValues tsIdDocValues = docValuesProducer.getSorted(fieldInfos.fieldInfo(TS_ID));
+        /**
+         * Returns the _tsid ordinal value for a given docID. The document ID must exist and must have a value for the field.
+         *
+         * @param docID the docID
+         * @return the _tsid ordinal value
+         * @throws IOException if any I/O exception occurs
+         */
+        private int docTsIdOrdinal(int docID) throws IOException {
+            if (tsIdDocValues == null || tsIdDocValues.docID() > docID) {
+                tsIdDocValues = docValuesProducer.getSorted(tsIdFieldInfo);
+                cachedTsIdOrd = -1;
+                cachedTsId = null;
+            }
             boolean found = tsIdDocValues.advanceExact(docID);
-            assert found;
-            int tsIdOrd = tsIdDocValues.ordValue();
-            BytesRef tsId = tsIdDocValues.lookupOrd(tsIdOrd);
-            assert tsId != null;
+            assert found : "No value found for field [" + tsIdFieldInfo.getName() + " and docID " + docID;
+            return tsIdDocValues.ordValue();
+        }
 
-            // Retrieve timestamp
-            SortedNumericDocValues timestampDocValues = docValuesProducer.getSortedNumeric(fieldInfos.fieldInfo(TIMESTAMP));
-            found = timestampDocValues.advanceExact(docID);
-            assert found;
+        /**
+         * Returns the timestamp value for a given docID. The document ID must exist and must have a value for the field.
+         *
+         * @param docID the docID
+         * @return the timestamp value
+         * @throws IOException if any I/O exception occurs
+         */
+        private long docTimestamp(int docID) throws IOException {
+            if (timestampDocValues == null || timestampDocValues.docID() > docID) {
+                timestampDocValues = docValuesProducer.getSortedNumeric(timestampFieldInfo);
+            }
+            boolean found = timestampDocValues.advanceExact(docID);
+            assert found : "No value found for field [" + timestampFieldInfo.getName() + " and docID " + docID;
             assert timestampDocValues.docValueCount() == 1;
-            long timestamp = timestampDocValues.nextValue();
+            return timestampDocValues.nextValue();
+        }
 
-            // Retrieve routing hash
-            var tsRoutingHash = fieldInfos.fieldInfo(TimeSeriesRoutingHashFieldMapper.NAME);
-            assert tsRoutingHash != null;
-            SortedDocValues routingHashDocValues = docValuesProducer.getSorted(tsRoutingHash);
-            found = routingHashDocValues.advanceExact(docID);
-            assert found;
-            BytesRef routingHashBytes = routingHashDocValues.lookupOrd(routingHashDocValues.ordValue());
+        /**
+         * Returns the routing hash value for a given docID. The document ID must exist and must have a value for the field.
+         *
+         * @param docID the docID
+         * @return the routing hash value
+         * @throws IOException if any I/O exception occurs
+         */
+        private BytesRef docRoutingHash(int docID) throws IOException {
+            if (routingHashDocValues == null || routingHashDocValues.docID() > docID) {
+                routingHashDocValues = docValuesProducer.getSorted(routingHashFieldInfo);
+            }
+            boolean found = routingHashDocValues.advanceExact(docID);
+            assert found : "No value found for field [" + routingHashFieldInfo.getName() + " and docID " + docID;
+            return routingHashDocValues.lookupOrd(routingHashDocValues.ordValue());
+        }
 
-            int routingHash = TimeSeriesRoutingHashFieldMapper.decode(
-                Uid.decodeId(routingHashBytes.bytes, routingHashBytes.offset, routingHashBytes.length)
-            );
-            term = Uid.encodeId(TsidExtractingIdFieldMapper.createId(routingHash, tsId, timestamp));
-            latestTimestamp = timestamp;
-            latestTsId = tsId;
-            return term;
+        /**
+         * Lookup if a given _tsid exists, returning a positive ordinal if it exists otherwise it returns -insertionPoint-1.
+         *
+         * @param tsId the _tsid to look up
+         * @return a positive ordinal if the _tsid exists, else returns -insertionPoint-1.
+         * @throws IOException if any I/O exception occurs
+         */
+        private int lookupTsIdTerm(BytesRef tsId) throws IOException {
+            int compare = Integer.MAX_VALUE;
+            if (cachedTsId != null) {
+                compare = cachedTsId.compareTo(tsId);
+                if (compare == 0) {
+                    return cachedTsIdOrd;
+                }
+            }
+            if (tsIdDocValues == null || compare > 0) {
+                tsIdDocValues = docValuesProducer.getSorted(tsIdFieldInfo);
+                cachedTsIdOrd = -1;
+                cachedTsId = null;
+            }
+            int ordinal = tsIdDocValues.lookupTerm(tsId);
+            if (0 <= ordinal) {
+                cachedTsIdOrd = ordinal;
+                cachedTsId = tsId;
+            }
+            return ordinal;
+        }
+
+        /**
+         * Lookup the _tsid value for the given ordinal.
+         *
+         * @param tsIdOrdinal the _tsid  ordinal
+         * @return the _tsid value
+         * @throws IOException if any I/O exception occurs
+         */
+        private BytesRef lookupTsIdOrd(int tsIdOrdinal) throws IOException {
+            if (cachedTsIdOrd != -1 && cachedTsIdOrd == tsIdOrdinal) {
+                return cachedTsId;
+            }
+            if (tsIdDocValues == null || tsIdDocValues.ordValue() > tsIdOrdinal) {
+                tsIdDocValues = docValuesProducer.getSorted(tsIdFieldInfo);
+                cachedTsIdOrd = -1;
+                cachedTsId = null;
+            }
+            assert 0 <= tsIdOrdinal : tsIdOrdinal;
+            assert tsIdOrdinal < tsIdDocValues.getValueCount() : tsIdOrdinal;
+            var tsId = tsIdDocValues.lookupOrd(tsIdOrdinal);
+            if (tsId != null) {
+                cachedTsIdOrd = tsIdOrdinal;
+                cachedTsId = tsId;
+            }
+            return tsId;
+        }
+
+        /**
+         * Scan all documents to find the first document that has a _tsid equal or greater than the provided _tsid ordinal, returning its
+         * document ID. If no document is found, the method returns {@link DocIdSetIterator#NO_MORE_DOCS}.
+         *
+         * Warning: This method is very slow because it potentially scans all documents in the segment.
+         */
+        private int slowScanToFirstDocWithTsIdOrdinalEqualOrGreaterThan(int tsIdOrd) throws IOException {
+            // recreate even if doc values are already on the same ordinal, to ensure the method returns the first doc
+            if (tsIdDocValues == null || (cachedTsIdOrd != -1 && cachedTsIdOrd >= tsIdOrd)) {
+                tsIdDocValues = docValuesProducer.getSorted(tsIdFieldInfo);
+                cachedTsIdOrd = -1;
+                cachedTsId = null;
+            }
+            assert 0 <= tsIdOrd : tsIdOrd;
+            assert tsIdOrd < tsIdDocValues.getValueCount() : tsIdOrd;
+
+            for (int docID = 0; docID != DocIdSetIterator.NO_MORE_DOCS; docID = tsIdDocValues.nextDoc()) {
+                boolean found = tsIdDocValues.advanceExact(docID);
+                assert found : "No value found for field [" + tsIdFieldInfo.getName() + " and docID " + docID;
+                var ord = tsIdDocValues.ordValue();
+                if (ord == tsIdOrd || tsIdOrd < ord) {
+                    if (ord != cachedTsIdOrd) {
+                        cachedTsId = tsIdDocValues.lookupOrd(ord);
+                        cachedTsIdOrd = ord;
+                    }
+                    return docID;
+                }
+            }
+            cachedTsIdOrd = -1;
+            cachedTsId = null;
+            return DocIdSetIterator.NO_MORE_DOCS;
+        }
+
+        /**
+         * Scan all documents to find the first document that has a _tsid equal to the provided _tsid ordinal, returning its
+         * document ID. If no document is found, the method returns {@link DocIdSetIterator#NO_MORE_DOCS}.
+         *
+         * Warning: This method is very slow because it potentially scans all documents in the segment.
+         */
+        private int slowScanToFirstDocWithTsIdOrdinalEqualTo(int tsIdOrd) throws IOException {
+            // recreate even if doc values are already on the same ordinal, to ensure the method returns the first doc
+            if (tsIdDocValues == null || (cachedTsIdOrd != -1 && cachedTsIdOrd >= tsIdOrd)) {
+                tsIdDocValues = docValuesProducer.getSorted(tsIdFieldInfo);
+                cachedTsIdOrd = -1;
+                cachedTsId = null;
+            }
+            assert 0 <= tsIdOrd : tsIdOrd;
+            assert tsIdOrd < tsIdDocValues.getValueCount() : tsIdOrd;
+
+            for (int docID = 0; docID != DocIdSetIterator.NO_MORE_DOCS; docID = tsIdDocValues.nextDoc()) {
+                boolean found = tsIdDocValues.advanceExact(docID);
+                assert found : "No value found for field [" + tsIdFieldInfo.getName() + " and docID " + docID;
+                var ord = tsIdDocValues.ordValue();
+                if (ord == tsIdOrd) {
+                    if (ord != cachedTsIdOrd) {
+                        cachedTsId = tsIdDocValues.lookupOrd(ord);
+                        cachedTsIdOrd = ord;
+                    }
+                    return docID;
+                } else if (tsIdOrd < ord) {
+                    break;
+                }
+            }
+            cachedTsIdOrd = -1;
+            cachedTsId = null;
+            assert false : "Method must be called with an existing _tsid ordinal: " + tsIdOrd;
+            return DocIdSetIterator.NO_MORE_DOCS;
+        }
+
+        private int getTsIdValueCount() throws IOException {
+            if (tsIdDocValues == null) {
+                tsIdDocValues = docValuesProducer.getSorted(tsIdFieldInfo);
+            }
+            return tsIdDocValues.getValueCount();
+        }
+    }
+
+    /**
+     * Represents the synthetic term the {@link TermsEnum} or {@link PostingsEnum} is positioned on. It points to a given docID and its
+     * corresponding _tsid, @timestamp and _ts_routing_hash values. The {@link #term()} method returns the synthetic _id of the document.
+     */
+    private record SyntheticTerm(int docID, int tsIdOrd, BytesRef tsId, long timestamp, BytesRef routingHash) {
+        private BytesRef term() {
+            assert docID >= 0 : docID;
+            assert tsIdOrd >= 0 : tsIdOrd;
+            return syntheticId(tsId, timestamp, routingHash);
+        }
+    }
+
+    /**
+     * When returned by next(), seekCeil(), nextDoc() and docID() it means there are no more synthetic terms in the {@link TermsEnum}
+     * or {@link PostingsEnum}.
+     */
+    private static final SyntheticTerm NO_MORE_DOCS = new SyntheticTerm(DocIdSetIterator.NO_MORE_DOCS, -1, null, -1L, null);
+
+    /**
+     * {@link TermsEnum} to iterate over documents synthetic _ids.
+     */
+    private class SyntheticIdTermsEnum extends BaseTermsEnum {
+
+        /**
+         * Holds all doc values that composed the synthetic _id
+         */
+        private final DocValuesHolder docValues;
+
+        /**
+         * Current synthetic term the enum is positioned on. It points to 1 document.
+         */
+        private SyntheticTerm current;
+
+        private SyntheticIdTermsEnum() {
+            this.docValues = new DocValuesHolder(fieldInfos, docValuesProducer);
+            this.current = null;
+        }
+
+        private void ensurePositioned() {
+            if (current == null || current == NO_MORE_DOCS) {
+                assert false;
+                throw new IllegalStateException("Method should not be called when unpositioned");
+            }
         }
 
         @Override
-        public SeekStatus seekCeil(BytesRef id) {
-            assert id != null;
-            if (term != null && term.equals(id)) {
-                return SeekStatus.FOUND;
+        public BytesRef next() throws IOException {
+            if (current == NO_MORE_DOCS) {
+                return null;
             }
-            try {
-                while (next() != null) {
-                    if (term.equals(id)) {
-                        return SeekStatus.FOUND;
+
+            int docID = (current != null) ? current.docID + 1 : 0;
+            if (maxDocs <= docID) {
+                current = NO_MORE_DOCS;
+                return null;
+            }
+            int tsIdOrdinal = docValues.docTsIdOrdinal(docID);
+            current = new SyntheticTerm(
+                docID,
+                tsIdOrdinal,
+                docValues.lookupTsIdOrd(tsIdOrdinal),
+                docValues.docTimestamp(docID),
+                docValues.docRoutingHash(docID)
+            );
+            return current.term();
+        }
+
+        @Override
+        public SeekStatus seekCeil(BytesRef id) throws IOException {
+
+            assert id != null;
+            assert Long.BYTES + Integer.BYTES < id.length : id.length;
+            if (id == null || id.length <= Long.BYTES + Integer.BYTES) {
+                return SeekStatus.NOT_FOUND;
+            }
+
+            // Extract the _tsid
+            final BytesRef tsId = TsidExtractingIdFieldMapper.extractTimeSeriesIdFromSyntheticId(id);
+            int tsIdOrd = docValues.lookupTsIdTerm(tsId);
+
+            // _tsid not found
+            if (tsIdOrd < 0) {
+                tsIdOrd = -tsIdOrd - 1;
+                // set the terms enum on the first non-matching document
+                if (tsIdOrd < docValues.getTsIdValueCount()) {
+                    int docID = docValues.slowScanToFirstDocWithTsIdOrdinalEqualOrGreaterThan(tsIdOrd);
+                    if (docID != DocIdSetIterator.NO_MORE_DOCS) {
+                        current = new SyntheticTerm(
+                            docID,
+                            tsIdOrd,
+                            docValues.lookupTsIdOrd(tsIdOrd),
+                            docValues.docTimestamp(docID),
+                            docValues.docRoutingHash(docID)
+                        );
+                        return SeekStatus.NOT_FOUND;
                     }
                 }
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
+                // no docs/terms to iterate on
+                current = NO_MORE_DOCS;
+                return SeekStatus.END;
             }
+
+            // _tsid found, extract the timestamp
+            final long timestamp = TsidExtractingIdFieldMapper.extractTimestampFromSyntheticId(id);
+
+            // Slow scan to the first document matching the _tsid
+            final int startDocID = docValues.slowScanToFirstDocWithTsIdOrdinalEqualTo(tsIdOrd);
+            assert startDocID >= 0 : startDocID;
+
+            int docID = startDocID;
+            int docTsIdOrd = tsIdOrd;
+            long docTimestamp;
+
+            // Iterate over documents to find the first one matching the timestamp
+            for (; docID < maxDocs; docID++) {
+                docTimestamp = docValues.docTimestamp(docID);
+                if (startDocID < docID) {
+                    // After the first doc, we need to check again if _tsid matches
+                    docTsIdOrd = docValues.docTsIdOrdinal(docID);
+                }
+                if (docTsIdOrd == tsIdOrd && docTimestamp == timestamp) {
+                    // It's a match!
+                    current = new SyntheticTerm(docID, tsIdOrd, tsId, docTimestamp, docValues.docRoutingHash(docID));
+                    return SeekStatus.FOUND;
+                }
+                // Remaining docs don't match, stop here
+                if (tsIdOrd < docTsIdOrd || docTimestamp < timestamp) {
+                    break;
+                }
+            }
+            current = NO_MORE_DOCS;
             return SeekStatus.END;
         }
 
         @Override
         public BytesRef term() {
-            return term;
+            ensurePositioned();
+            return current.term();
         }
 
         @Override
         public PostingsEnum postings(PostingsEnum reuse, int flags) {
-            return new FakePostingsEnum(docID, latestTsId, latestTimestamp, maxDocs);
+            ensurePositioned();
+            return new SyntheticIdPostingsEnum(current);
         }
 
         /**
@@ -258,23 +536,19 @@ public class TSDBSyntheticIdFieldsProducer extends FieldsProducer {
         }
     }
 
-    /**
-     * Do not use in production. See {@link FakeTermsEnum}.
-     */
-    private class FakePostingsEnum extends PostingsEnum {
+    private class SyntheticIdPostingsEnum extends PostingsEnum {
 
-        private final int startDocID;
-        private final BytesRef latestTsId;
-        private final long latestTimestamp;
-        private final int maxDocs;
-        private int docID;
+        private final DocValuesHolder docValues;
 
-        private FakePostingsEnum(int docID, BytesRef latestTsId, long latestTimestamp, int maxDocs) {
-            this.startDocID = docID;
-            this.latestTsId = latestTsId;
-            this.latestTimestamp = latestTimestamp;
-            this.maxDocs = maxDocs;
-            this.docID = -1;
+        /**
+         * Current synthetic term the postings is pinned on.
+         */
+        private final SyntheticTerm term;
+        private int docID = -1;
+
+        private SyntheticIdPostingsEnum(SyntheticTerm term) {
+            this.docValues = new DocValuesHolder(fieldInfos, docValuesProducer);
+            this.term = Objects.requireNonNull(term);
         }
 
         @Override
@@ -286,61 +560,27 @@ public class TSDBSyntheticIdFieldsProducer extends FieldsProducer {
         public int nextDoc() throws IOException {
             if (docID == DocIdSetIterator.NO_MORE_DOCS) {
                 return docID;
-            } else if (docID == -1) {
-                docID = startDocID;
-            } else {
-                docID = docID + 1;
-                if (maxDocs <= docID) {
-                    docID = DocIdSetIterator.NO_MORE_DOCS;
-                    return docID;
+            }
+            int nextDocID = (docID == -1) ? term.docID() : docID + 1;
+            if (nextDocID < maxDocs) {
+                int tsIdOrd = docValues.docTsIdOrdinal(nextDocID);
+                if (tsIdOrd == term.tsIdOrd()) {
+                    long timestamp = docValues.docTimestamp(nextDocID);
+                    if (timestamp == term.timestamp()) {
+                        assert Objects.equals(docValues.docRoutingHash(nextDocID), term.routingHash());
+                        assert Objects.equals(docValues.lookupTsIdOrd(tsIdOrd), term.tsId());
+                        docID = nextDocID;
+                        return docID;
+                    }
                 }
             }
-
-            // Retrieve _tsid
-            SortedDocValues tsIdDocValues = docValuesProducer.getSorted(fieldInfos.fieldInfo(TS_ID));
-            boolean found = tsIdDocValues.advanceExact(docID);
-            assert found;
-            int tsIdOrd = tsIdDocValues.ordValue();
-            BytesRef tsId = tsIdDocValues.lookupOrd(tsIdOrd);
-            assert tsId != null;
-
-            if (latestTsId != null && latestTsId.equals(tsId) == false) {
-                // Different _tsid, stop here
-                docID = DocIdSetIterator.NO_MORE_DOCS;
-                return docID;
-            }
-
-            // Retrieve timestamp
-            SortedNumericDocValues timestampDocValues = docValuesProducer.getSortedNumeric(fieldInfos.fieldInfo(TIMESTAMP));
-            found = timestampDocValues.advanceExact(docID);
-            assert found;
-            assert timestampDocValues.docValueCount() == 1;
-            long timestamp = timestampDocValues.nextValue();
-
-            if (latestTimestamp != -1L && latestTimestamp != timestamp) {
-                // Different @timestamp, stop here
-                docID = DocIdSetIterator.NO_MORE_DOCS;
-                return docID;
-            }
-
-            // Retrieve routing hash
-            var tsRoutingHash = fieldInfos.fieldInfo(TimeSeriesRoutingHashFieldMapper.NAME);
-            assert tsRoutingHash != null;
-            SortedDocValues routingHashDocValues = docValuesProducer.getSorted(tsRoutingHash);
-            found = routingHashDocValues.advanceExact(docID);
-            assert found;
-            BytesRef routingHashBytes = routingHashDocValues.lookupOrd(routingHashDocValues.ordValue());
-            assert routingHashBytes != null;
+            docID = DocIdSetIterator.NO_MORE_DOCS;
             return docID;
         }
 
         @Override
         public int advance(int target) throws IOException {
-            int doc;
-            while ((doc = nextDoc()) < target) {
-                // Continue
-            }
-            return doc;
+            return slowAdvance(target);
         }
 
         @Override
@@ -372,6 +612,15 @@ public class TSDBSyntheticIdFieldsProducer extends FieldsProducer {
         public BytesRef getPayload() throws IOException {
             return null; // not supported
         }
+    }
+
+    private static BytesRef syntheticId(BytesRef tsId, long timestamp, BytesRef routingHashBytes) {
+        assert tsId != null;
+        assert timestamp > 0L;
+        assert routingHashBytes != null;
+        String routingHashString = Uid.decodeId(routingHashBytes.bytes, routingHashBytes.offset, routingHashBytes.length);
+        int routingHash = TimeSeriesRoutingHashFieldMapper.decode(routingHashString);
+        return TsidExtractingIdFieldMapper.createSyntheticIdBytesRef(tsId, timestamp, routingHash);
     }
 
     private static boolean assertFieldInfosExist(FieldInfos fieldInfos, String... fieldNames) {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormat.java
@@ -19,6 +19,7 @@ import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
 import org.elasticsearch.index.mapper.SyntheticIdField;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
+import org.elasticsearch.index.mapper.TimeSeriesRoutingHashFieldMapper;
 
 import java.io.IOException;
 
@@ -27,6 +28,7 @@ public class TSDBSyntheticIdPostingsFormat extends PostingsFormat {
     public static final String SYNTHETIC_ID = SyntheticIdField.NAME;
     public static final String TIMESTAMP = DataStreamTimestampFieldMapper.DEFAULT_PATH;
     public static final String TS_ID = TimeSeriesIdFieldMapper.NAME;
+    public static final String TS_ROUTING_HASH = TimeSeriesRoutingHashFieldMapper.NAME;
 
     static final String FORMAT_NAME = "TSDBSyntheticId";
     static final String SUFFIX = "0";

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -245,7 +245,7 @@ public class InternalEngine extends Engine {
     InternalEngine(EngineConfig engineConfig, int maxDocs, BiFunction<Long, Long, LocalCheckpointTracker> localCheckpointTrackerSupplier) {
         super(engineConfig);
         this.maxDocs = maxDocs;
-        if (engineConfig.getIndexSettings().useTsdbSyntheticId()) {
+        if (engineConfig.getIndexSettings().useTimeSeriesSyntheticId()) {
             logger.info("using TSDB with synthetic id");
             useTsdbSyntheticId = true;
         } else {
@@ -1067,7 +1067,13 @@ public class InternalEngine extends Engine {
                 directoryReader -> {
                     if (engineConfig.getIndexSettings().getMode() == IndexMode.TIME_SERIES) {
                         assert engineConfig.getLeafSorter() == DataStream.TIMESERIES_LEAF_READERS_SORTER;
-                        return VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(directoryReader, op.uid(), op.id(), loadSeqNo);
+                        return VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(
+                            directoryReader,
+                            op.uid(),
+                            op.id(),
+                            loadSeqNo,
+                            useTsdbSyntheticId
+                        );
                     } else {
                         return VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(directoryReader, op.uid(), loadSeqNo);
                     }
@@ -1442,7 +1448,7 @@ public class InternalEngine extends Engine {
         index.parsedDoc().updateSeqID(index.seqNo(), index.primaryTerm());
         index.parsedDoc().version().setLongValue(plan.versionForIndexing);
         try {
-            logDocumentsDetails(index.docs());
+            logDocumentsDetails(index.docs(), index.id(), index.uid());
             if (plan.addStaleOpToLucene) {
                 addStaleDocs(index.docs(), indexWriter);
             } else if (plan.useLuceneUpdateDocument) {
@@ -1478,10 +1484,10 @@ public class InternalEngine extends Engine {
         }
     }
 
-    private void logDocumentsDetails(List<LuceneDocument> docs) {
+    private void logDocumentsDetails(List<LuceneDocument> docs, String id, BytesRef uid) {
         if (useTsdbSyntheticId && logger.isTraceEnabled()) {
             for (var doc : docs) {
-                logger.trace("indexing document fields [{}]", doc.getFields());
+                logger.trace("indexing document [id: {}, uid: {}]:\n{}\r\n", id, uid, doc.getFields());
             }
         }
     }
@@ -1859,8 +1865,10 @@ public class InternalEngine extends Engine {
         try {
             final ParsedDocument tombstone = ParsedDocument.deleteTombstone(
                 engineConfig.getIndexSettings().seqNoIndexOptions(),
+                engineConfig.getIndexSettings().useDocValuesSkipper(),
                 useTsdbSyntheticId,
-                delete.id()
+                delete.id(),
+                delete.uid()
             );
             assert tombstone.docs().size() == 1 : "Tombstone doc should have single doc [" + tombstone + "]";
             tombstone.updateSeqID(delete.seqNo(), delete.primaryTerm());
@@ -1869,6 +1877,7 @@ public class InternalEngine extends Engine {
             assert doc.getField(SeqNoFieldMapper.TOMBSTONE_NAME) != null
                 : "Delete tombstone document but _tombstone field is not set [" + doc + " ]";
             doc.add(softDeletesField);
+            logDocumentsDetails(List.of(doc), delete.id(), delete.uid());
             if (plan.addStaleOpToLucene || plan.currentlyDeleted) {
                 indexWriter.addDocument(doc);
             } else {
@@ -2806,7 +2815,7 @@ public class InternalEngine extends Engine {
             new SoftDeletesRetentionMergePolicy(
                 Lucene.SOFT_DELETES_FIELD,
                 () -> softDeletesPolicy.getRetentionQuery(engineConfig.getIndexSettings().seqNoIndexOptions()),
-                new PrunePostingsMergePolicy(mergePolicy, IdFieldMapper.NAME)
+                useTsdbSyntheticId ? mergePolicy : new PrunePostingsMergePolicy(mergePolicy, IdFieldMapper.NAME)
             )
         );
         if (SHUFFLE_FORCE_MERGE) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
@@ -10,6 +10,9 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -73,7 +76,7 @@ public class ParsedDocument {
      * @param id                the id of the deleted document
      */
     public static ParsedDocument deleteTombstone(SeqNoFieldMapper.SeqNoIndexOptions seqNoIndexOptions, String id) {
-        return deleteTombstone(seqNoIndexOptions, false, id);
+        return deleteTombstone(seqNoIndexOptions, false /* ignored */, false, id, null /* ignored */);
     }
 
     /**
@@ -82,7 +85,13 @@ public class ParsedDocument {
      * @param useSyntheticId    whether the id is synthetic or not
      * @param id                the id of the deleted document
      */
-    public static ParsedDocument deleteTombstone(SeqNoFieldMapper.SeqNoIndexOptions seqNoIndexOptions, boolean useSyntheticId, String id) {
+    public static ParsedDocument deleteTombstone(
+        SeqNoFieldMapper.SeqNoIndexOptions seqNoIndexOptions,
+        boolean useDocValuesSkipper,
+        boolean useSyntheticId,
+        String id,
+        BytesRef uid
+    ) {
         LuceneDocument document = new LuceneDocument();
         SeqNoFieldMapper.SequenceIDFields seqIdFields = SeqNoFieldMapper.SequenceIDFields.tombstone(seqNoIndexOptions);
         seqIdFields.addFields(document);
@@ -91,7 +100,21 @@ public class ParsedDocument {
         if (useSyntheticId) {
             // Use a synthetic _id field which is not indexed nor stored
             document.add(IdFieldMapper.syntheticIdField(id));
-            // TODO I think we also need to add the fields that compose the synthetic _id.
+
+            var timeSeriesId = TsidExtractingIdFieldMapper.extractTimeSeriesIdFromSyntheticId(uid);
+            var timestamp = TsidExtractingIdFieldMapper.extractTimestampFromSyntheticId(uid);
+            var routingHash = TsidExtractingIdFieldMapper.extractRoutingHashBytesFromSyntheticId(uid);
+
+            if (useDocValuesSkipper) {
+                document.add(SortedDocValuesField.indexedField(TimeSeriesIdFieldMapper.NAME, timeSeriesId));
+                document.add(SortedNumericDocValuesField.indexedField("@timestamp", timestamp));
+            } else {
+                document.add(new SortedDocValuesField(TimeSeriesIdFieldMapper.NAME, timeSeriesId));
+                document.add(new LongField("@timestamp", timestamp, Field.Store.NO));
+            }
+            var field = new SortedDocValuesField(TimeSeriesRoutingHashFieldMapper.NAME, routingHash);
+            document.add(field);
+
         } else {
             // Use standard _id field (indexed and stored, some indices also trim the stored field at some point)
             document.add(IdFieldMapper.standardIdField(id));

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -971,7 +971,7 @@ final class DefaultSearchContext extends SearchContext {
                     }
                 }
             }
-            return IdLoader.createTsIdLoader(indexRouting, routingPaths);
+            return IdLoader.createTsIdLoader(indexRouting, routingPaths, indexService.getIndexSettings().useTimeSeriesSyntheticId());
         } else {
             return IdLoader.fromLeafStoredFieldLoader();
         }

--- a/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionLookupTests.java
@@ -159,7 +159,7 @@ public class VersionLookupTests extends ESTestCase {
         Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER).setMergePolicy(NoMergePolicy.INSTANCE));
         var randomSeqNoIndexOptions = randomFrom(SeqNoFieldMapper.SeqNoIndexOptions.values());
-        writer.addDocument(ParsedDocument.deleteTombstone(randomSeqNoIndexOptions, false, "_id").docs().get(0));
+        writer.addDocument(ParsedDocument.deleteTombstone(randomSeqNoIndexOptions, "_id").docs().get(0));
         DirectoryReader reader = DirectoryReader.open(writer);
         LeafReaderContext segment = reader.leaves().get(0);
         PerThreadIDVersionAndSeqNoLookup lookup = new PerThreadIDVersionAndSeqNoLookup(segment.reader(), true);

--- a/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionsTests.java
@@ -200,7 +200,7 @@ public class VersionsTests extends ESTestCase {
         DirectoryReader directoryReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer), new ShardId("foo", "_na_", 1));
         String id = createTSDBId(1000L);
         assertThat(
-            VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(directoryReader, new BytesRef("1"), id, randomBoolean()),
+            VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(directoryReader, new BytesRef("1"), id, randomBoolean(), false),
             nullValue()
         );
 
@@ -222,11 +222,23 @@ public class VersionsTests extends ESTestCase {
         directoryReader = reopen(directoryReader);
 
         id = createTSDBId(randomLongBetween(1000, 10000));
-        assertThat(VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(directoryReader, new BytesRef("1"), id, true), notNullValue());
-        assertThat(VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(directoryReader, new BytesRef("2"), id, true), notNullValue());
+        assertThat(
+            VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(directoryReader, new BytesRef("1"), id, true, false),
+            notNullValue()
+        );
+        assertThat(
+            VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(directoryReader, new BytesRef("2"), id, true, false),
+            notNullValue()
+        );
         id = createTSDBId(randomBoolean() ? randomLongBetween(0, 999) : randomLongBetween(10001, Long.MAX_VALUE));
-        assertThat(VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(directoryReader, new BytesRef("1"), id, true), nullValue());
-        assertThat(VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(directoryReader, new BytesRef("2"), id, true), nullValue());
+        assertThat(
+            VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(directoryReader, new BytesRef("1"), id, true, false),
+            nullValue()
+        );
+        assertThat(
+            VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(directoryReader, new BytesRef("2"), id, true, false),
+            nullValue()
+        );
 
         directoryReader.close();
         writer.close();

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -4571,7 +4571,7 @@ public class IndexShardTests extends IndexShardTestCase {
     public void testSupplyTombstoneDoc() throws Exception {
         IndexShard shard = newStartedShard();
         String id = randomRealisticUnicodeOfLengthBetween(1, 10);
-        ParsedDocument deleteTombstone = ParsedDocument.deleteTombstone(shard.indexSettings.seqNoIndexOptions(), randomBoolean(), id);
+        ParsedDocument deleteTombstone = ParsedDocument.deleteTombstone(shard.indexSettings.seqNoIndexOptions(), id);
         assertThat(deleteTombstone.docs(), hasSize(1));
         LuceneDocument deleteDoc = deleteTombstone.docs().get(0);
         assertThat(


### PR DESCRIPTION
This change follows #136810 and introduces a new format for documents `_id` fields in time-series datastreams. In order to test this new format, the TSDB synthetic terms and postings format implementations are also changed.

#### Why change the document _id format?
The current _id format is composed of a routing hash, the hashed value of the _tsid and a timestamp. While it is possible to extract the routing hash and the timestamp from a document _id value, it is not possible to extract the original _tsid value. 

This is an issue for synthetic `_id` as the document `_id` value is not indexed anymore: instead the synthetic `_id` is computed at runtime from the value of the routing hash, `_tsid` and timestamp. Therefore we need to be able to extract the routing hash/_tsid/timestamp values from the _id value and vice-versa.

The format for the synthetic _id in this pull request has been changed to be:
- `_tsid` (variable length)
- Long.MAX_VALUE - timestamp (unsigned long on 8 bytes encoded using big endian)
- routing hash `_ts_routing_hash` (4 bytes)

Extracting the values from the _id is then used for routing GETs and DELETEs requests to the appropriate shard or setting the _tsid/timestamp/_ts_routing_hash fields in tombstone documents.

Note that in searches, the document _id is built using the existing `TsIdLoader` (that has been adjusted).

It is also important that the generated _id can be sorted lexicographically, as Lucene stops applying doc values updates when it seeks to a term that is greater than the one used in the soft-update. The ordering of the arrays of bytes representing the `_id` must match the ordering of documents in the segment, and to do that the timestamp value is stored in the array as `Long.MAX_VALUE - timestamp`. Docs with higher timestamp are then sorted first.

#### Impact on synthetic terms and postings format
The `SyntheticIdTermsEnum` and `SyntheticIdPostingsEnum` introduced in #136810 had to be adjusted for the new `_id` format. We expect their implementation to be somewhat slow as it requires several lookups to work. In a different change we'll add a bloom filter on top of these enumerations to avoid costly lookups.

In contrast to #136810, `SyntheticIdTermsEnum` and `SyntheticIdPostingsEnum` implementations are ready for reviews.

#### Tests improvements

Tests have been improved to delete random documents and/or lookup documents from in-memory or flushed to disk segments. Searches and search-by-id should also work.

The following feature are NOT covered by tests:
- aggregations over _id likely do not work
- nested-docs (if that's possible in time-series datastreams?)
- and many more (split/clone, malformed _ids  rejections etc)