### PR TITLE
Mirror upstream elastic/elasticsearch#137317 for AI review (snapshot of HEAD tree)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/index/IndexResolution.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/index/IndexResolution.java
@@ -41,6 +41,10 @@ public final class IndexResolution {
         return new IndexResolution(null, invalid, Set.of(), Map.of());
     }
 
+    public static IndexResolution empty(String indexPattern) {
+        return valid(new EsIndex(indexPattern, Map.of(), Map.of()));
+    }
+
     public static IndexResolution notFound(String name) {
         Objects.requireNonNull(name, "name must not be null");
         return invalid("Unknown index [" + name + "]");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.session;
 
 import org.elasticsearch.ElasticsearchSecurityException;
-import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesFailure;
@@ -310,52 +309,35 @@ public class EsqlCCSUtils {
     }
 
     /**
-     * Checks the index expression for the presence of remote clusters.
-     * If found, it will ensure that the caller has a valid Enterprise (or Trial) license on the querying cluster
-     * as well as initialize the corresponding cluster state in execution info.
-     * @throws org.elasticsearch.ElasticsearchStatusException if the license is not valid (or present) for ES|QL CCS search.
+     * This inits the cross cluster state in executionInfo using `indicesGrouper`
+     * when original to resolved index mapping is not available in field caps response
      */
-    public static void initCrossClusterState(
+    public static void initCrossClusterInfo(
         IndicesExpressionGrouper indicesGrouper,
         XPackLicenseState licenseState,
-        Set<IndexPattern> indexPatterns,
+        IndexPattern indexPattern,
         EsqlExecutionInfo executionInfo
-    ) throws ElasticsearchStatusException {
-        if (indexPatterns.isEmpty()) {
-            return;
-        }
+    ) {
         try {
-            // TODO it is not safe to concat multiple index patterns in case any of them contains exclusion.
-            // This is going to be resolved in #136804
-            String[] indexExpressions = indexPatterns.stream()
-                .map(indexPattern -> Strings.splitStringByCommaToArray(indexPattern.indexPattern()))
-                .reduce((a, b) -> {
-                    String[] combined = new String[a.length + b.length];
-                    System.arraycopy(a, 0, combined, 0, a.length);
-                    System.arraycopy(b, 0, combined, a.length, b.length);
-                    return combined;
-                })
-                .get();
-            var groupedIndices = indicesGrouper.groupIndices(IndicesOptions.DEFAULT, indexExpressions, false);
+            var groupedIndices = indicesGrouper.groupIndices(
+                IndicesOptions.DEFAULT,
+                Strings.splitStringByCommaToArray(indexPattern.indexPattern()),
+                false
+            );
 
             executionInfo.clusterInfoInitializing(true);
             // initialize the cluster entries in EsqlExecutionInfo before throwing the invalid license error
             // so that the CCS telemetry handler can recognize that this error is CCS-related
             try {
-                for (var entry : groupedIndices.entrySet()) {
-                    final String clusterAlias = entry.getKey();
-                    final String indexExpr = Strings.arrayToCommaDelimitedString(entry.getValue().indices());
+                groupedIndices.forEach((clusterAlias, indexGroup) -> {
                     executionInfo.swapCluster(clusterAlias, (k, v) -> {
-                        assert v == null : "No cluster for " + clusterAlias + " should have been added to ExecutionInfo yet";
-                        return new EsqlExecutionInfo.Cluster(clusterAlias, indexExpr, executionInfo.shouldSkipOnFailure(clusterAlias));
+                        var thisPattern = Strings.arrayToCommaDelimitedString(indexGroup.indices());
+                        var clusterPattern = v == null ? thisPattern : v.getIndexExpression() + "," + thisPattern;
+                        return new EsqlExecutionInfo.Cluster(clusterAlias, clusterPattern, executionInfo.shouldSkipOnFailure(clusterAlias));
                     });
-                }
+                });
             } finally {
                 executionInfo.clusterInfoInitializing(false);
-            }
-
-            if (executionInfo.isCrossClusterSearch() && EsqlLicenseChecker.isCcsAllowed(licenseState) == false) {
-                throw EsqlLicenseChecker.invalidLicenseForCcsException(licenseState);
             }
         } catch (NoSuchRemoteClusterException e) {
             if (EsqlLicenseChecker.isCcsAllowed(licenseState)) {
@@ -363,6 +345,16 @@ public class EsqlCCSUtils {
             } else {
                 throw EsqlLicenseChecker.invalidLicenseForCcsException(licenseState);
             }
+        }
+    }
+
+    /**
+     * Ensures that the caller has a valid Enterprise (or Trial) license to perform CCS search
+     * @throws org.elasticsearch.ElasticsearchStatusException if the license is not valid (or present) for ES|QL CCS search.
+     */
+    public static void checkLicense(EsqlExecutionInfo executionInfo, XPackLicenseState licenseState) {
+        if (executionInfo.isCrossClusterSearch() && EsqlLicenseChecker.isCcsAllowed(licenseState) == false) {
+            throw EsqlLicenseChecker.invalidLicenseForCcsException(licenseState);
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
@@ -99,7 +99,7 @@ public class IndexResolver {
             (l, versionedResolution) -> l.onResponse(versionedResolution.inner())
         );
 
-        resolveAsMergedMappingAndRetrieveMinimumVersion(
+        resolve(
             indexWildcard,
             fieldNames,
             requestFilter,
@@ -114,7 +114,7 @@ public class IndexResolver {
      * Resolves a pattern to one (potentially compound meaning that spawns multiple indices) mapping. Also retrieves the minimum transport
      * version available in the cluster (and remotes).
      */
-    public void resolveAsMergedMappingAndRetrieveMinimumVersion(
+    public void resolve(
         String indexWildcard,
         Set<String> fieldNames,
         QueryBuilder requestFilter,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java
@@ -43,10 +43,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
-import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
-import static org.elasticsearch.xpack.esql.session.EsqlCCSUtils.initCrossClusterState;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -666,34 +663,90 @@ public class EsqlCCSUtilsTests extends ESTestCase {
     }
 
     public void testInitCrossClusterState() {
-        final TestIndicesExpressionGrouper indicesGrouper = new TestIndicesExpressionGrouper();
+        // local only
+        {
+            var local = new EsqlExecutionInfo(true);
 
+            EsqlCCSUtils.initCrossClusterInfo(
+                new TestIndicesExpressionGrouper(),
+                createLicenseState(null),
+                new IndexPattern(null, "index-1,index-2,index-*"),
+                local
+            );
+
+            assertThat(local.isCrossClusterSearch(), equalTo(false));
+            assertThat(local.getCluster(LOCAL_CLUSTER_ALIAS).getIndexExpression(), equalTo("index-1,index-2,index-*"));
+        }
+
+        // remote only
+        {
+            var remote = new EsqlExecutionInfo(true);
+
+            EsqlCCSUtils.initCrossClusterInfo(
+                new TestIndicesExpressionGrouper(),
+                createLicenseState(null),
+                new IndexPattern(null, "r1:index-1,r2:index-2,r3:index-*"),
+                remote
+            );
+
+            assertThat(remote.isCrossClusterSearch(), equalTo(true));
+            assertThat(remote.clusterAliases(), containsInAnyOrder("r1", "r2", "r3"));
+            assertThat(remote.getCluster("r1").getIndexExpression(), equalTo("index-1"));
+            assertThat(remote.getCluster("r2").getIndexExpression(), equalTo("index-2"));
+            assertThat(remote.getCluster("r3").getIndexExpression(), equalTo("index-*"));
+        }
+
+        // local and remote
+        {
+            var remoteAndLocal = new EsqlExecutionInfo(true);
+
+            EsqlCCSUtils.initCrossClusterInfo(
+                new TestIndicesExpressionGrouper(),
+                createLicenseState(null),
+                new IndexPattern(null, "r1:index-1,r2:index-2,index-*"),
+                remoteAndLocal
+            );
+
+            assertThat(remoteAndLocal.isCrossClusterSearch(), equalTo(true));
+            assertThat(remoteAndLocal.clusterAliases(), containsInAnyOrder(LOCAL_CLUSTER_ALIAS, "r1", "r2"));
+            assertThat(remoteAndLocal.getCluster(LOCAL_CLUSTER_ALIAS).getIndexExpression(), equalTo("index-*"));
+            assertThat(remoteAndLocal.getCluster("r1").getIndexExpression(), equalTo("index-1"));
+            assertThat(remoteAndLocal.getCluster("r2").getIndexExpression(), equalTo("index-2"));
+        }
+    }
+
+    public void testCheckLicense() {
         // local only search works with any license state
         {
-            var localOnly = new IndexPattern(EMPTY, randomFrom("idx", "idx1,idx2*"));
+            var localOnly = new EsqlExecutionInfo(true);
+            localOnly.swapCluster(LOCAL_CLUSTER_ALIAS, (k, v) -> new EsqlExecutionInfo.Cluster(LOCAL_CLUSTER_ALIAS, "idx", true));
 
-            assertLicenseCheckPasses(indicesGrouper, null, localOnly, "");
+            assertLicenseCheckPasses(localOnly, null);
             for (var mode : License.OperationMode.values()) {
-                assertLicenseCheckPasses(indicesGrouper, activeLicenseStatus(mode), localOnly, "");
-                assertLicenseCheckPasses(indicesGrouper, inactiveLicenseStatus(mode), localOnly, "");
+                assertLicenseCheckPasses(localOnly, activeLicenseStatus(mode));
+                assertLicenseCheckPasses(localOnly, inactiveLicenseStatus(mode));
             }
         }
 
         // cross-cluster search requires a valid (active, non-expired) enterprise license OR a valid trial license
         {
-            var remote = new IndexPattern(EMPTY, randomFrom("idx,remote:idx", "idx1,remote:idx2*,remote:logs"));
+            var remote = new EsqlExecutionInfo(true);
+            if (randomBoolean()) {
+                remote.swapCluster(LOCAL_CLUSTER_ALIAS, (k, v) -> new EsqlExecutionInfo.Cluster(LOCAL_CLUSTER_ALIAS, "idx", true));
+            }
+            remote.swapCluster("remote", (k, v) -> new EsqlExecutionInfo.Cluster("remote", "idx", true));
 
             var supportedLicenses = EnumSet.of(License.OperationMode.TRIAL, License.OperationMode.ENTERPRISE);
             var unsupportedLicenses = EnumSet.complementOf(supportedLicenses);
 
-            assertLicenseCheckFails(indicesGrouper, null, remote, "none");
+            assertLicenseCheckFails(remote, null, "none");
             for (var mode : supportedLicenses) {
-                assertLicenseCheckPasses(indicesGrouper, activeLicenseStatus(mode), remote, "", "remote");
-                assertLicenseCheckFails(indicesGrouper, inactiveLicenseStatus(mode), remote, "expired " + nameOf(mode) + " license");
+                assertLicenseCheckPasses(remote, activeLicenseStatus(mode));
+                assertLicenseCheckFails(remote, inactiveLicenseStatus(mode), "expired " + nameOf(mode) + " license");
             }
             for (var mode : unsupportedLicenses) {
-                assertLicenseCheckFails(indicesGrouper, activeLicenseStatus(mode), remote, "active " + nameOf(mode) + " license");
-                assertLicenseCheckFails(indicesGrouper, inactiveLicenseStatus(mode), remote, "expired " + nameOf(mode) + " license");
+                assertLicenseCheckFails(remote, activeLicenseStatus(mode), "active " + nameOf(mode) + " license");
+                assertLicenseCheckFails(remote, inactiveLicenseStatus(mode), "expired " + nameOf(mode) + " license");
             }
         }
     }
@@ -706,21 +759,13 @@ public class EsqlCCSUtilsTests extends ESTestCase {
         return status != null ? new XPackLicenseState(System::currentTimeMillis, status) : null;
     }
 
-    private void assertLicenseCheckPasses(
-        TestIndicesExpressionGrouper indicesGrouper,
-        XPackLicenseStatus status,
-        IndexPattern pattern,
-        String... expectedRemotes
-    ) {
-        var executionInfo = new EsqlExecutionInfo(true);
-        initCrossClusterState(indicesGrouper, createLicenseState(status), Set.of(pattern), executionInfo);
-        assertThat(executionInfo.clusterAliases(), containsInAnyOrder(expectedRemotes));
+    private void assertLicenseCheckPasses(EsqlExecutionInfo executionInfo, XPackLicenseStatus licenseStatus) {
+        EsqlCCSUtils.checkLicense(executionInfo, createLicenseState(licenseStatus));
     }
 
     private void assertLicenseCheckFails(
-        TestIndicesExpressionGrouper indicesGrouper,
+        EsqlExecutionInfo executionInfo,
         XPackLicenseStatus licenseStatus,
-        IndexPattern pattern,
         String expectedErrorMessageSuffix
     ) {
         ElasticsearchStatusException e = expectThrows(
@@ -728,7 +773,7 @@ public class EsqlCCSUtilsTests extends ESTestCase {
             equalTo(
                 "A valid Enterprise license is required to run ES|QL cross-cluster searches. License found: " + expectedErrorMessageSuffix
             ),
-            () -> initCrossClusterState(indicesGrouper, createLicenseState(licenseStatus), Set.of(pattern), new EsqlExecutionInfo(true))
+            () -> EsqlCCSUtils.checkLicense(executionInfo, createLicenseState(licenseStatus))
         );
         assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
     }
@@ -745,32 +790,34 @@ public class EsqlCCSUtilsTests extends ESTestCase {
         @Override
         public Map<String, OriginalIndices> groupIndices(IndicesOptions indicesOptions, String[] indexExpressions, boolean returnLocalAll) {
             final Map<String, OriginalIndices> originalIndicesMap = new HashMap<>();
-            final String localKey = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
-
             for (String expr : indexExpressions) {
                 assertFalse(Strings.isNullOrBlank(expr));
                 String[] split = expr.split(":", 2);
                 assertTrue("Bad index expression: " + expr, split.length < 3);
                 String clusterAlias;
-                String indexExpr;
+                String indexExpression;
                 if (split.length == 1) {
-                    clusterAlias = localKey;
-                    indexExpr = expr;
+                    clusterAlias = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+                    indexExpression = expr;
                 } else {
                     clusterAlias = split[0];
-                    indexExpr = split[1];
-
+                    indexExpression = split[1];
                 }
-                OriginalIndices currIndices = originalIndicesMap.get(clusterAlias);
-                if (currIndices == null) {
-                    originalIndicesMap.put(clusterAlias, new OriginalIndices(new String[] { indexExpr }, indicesOptions));
-                } else {
-                    List<String> indicesList = Arrays.stream(currIndices.indices()).collect(Collectors.toList());
-                    indicesList.add(indexExpr);
-                    originalIndicesMap.put(clusterAlias, new OriginalIndices(indicesList.toArray(new String[0]), indicesOptions));
-                }
+                assertFalse("* remote cluster resolution is not supported in test: " + expr, clusterAlias.contains("*"));
+                originalIndicesMap.compute(
+                    clusterAlias,
+                    (key, indices) -> indices == null
+                        ? new OriginalIndices(new String[] { indexExpression }, indicesOptions)
+                        : new OriginalIndices(append(indices.indices(), indexExpression), indicesOptions)
+                );
             }
             return originalIndicesMap;
+        }
+
+        private static String[] append(String[] original, String additional) {
+            var copy = Arrays.copyOf(original, original.length + 1);
+            copy[copy.length - 1] = additional;
+            return copy;
         }
     }
 }


### PR DESCRIPTION
Today we populate cross cluster state in esql execution info before performing main field caps.

This has several issues:
* it is populated from merged across different views main index patterns. This could Result in incorrect set of remotes when multiple patterns have exclusions in them (for example `logs-*,-*2024` + `metrics-*,-*2025` would incorrectly exclude logs-2025 and metrics-2024. This in turn can exclude the entire remote if those are the only indices on it).
* This performs `org.elasticsearch.indices.IndicesExpressionGrouper#groupIndices` that could not correctly expand flat/cps expressions.

This change moves cross cluster info population to after main field caps result is received.